### PR TITLE
Add CLAUDE.md and /code-review slash command

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,1 @@
+Read and follow the instructions in .claude/skills/code-review/SKILL.md to perform a code review of the current branch.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: code-review
+description: Review current branch for code quality, clarity, maintainability, performance, and security. Use when reviewing code, doing a code review, checking a PR, auditing code quality, optimizing slow paths, or checking for vulnerabilities. Triggers on "code review", "review this branch", "performance review", "review performance", "check performance", "security review", "review security", "check for vulnerabilities".
+metadata:
+  status: trial
+---
+
+# Code Review
+
+Review the current branch for code quality, clarity, and maintainability.
+
+## Workflow
+
+1. Determine the base branch (usually `main`) and run `git diff <base>...HEAD` to see all changes
+2. Read changed files in full to understand context
+3. Check `CLAUDE.md` for codebase conventions
+4. Evaluate each changed file against the review checklist below
+5. Produce the review using the output format below
+6. Verify: confirm all changed files from the diff are addressed in the review output
+
+## Focus Modes
+
+- Default mode: Use the general checklist in this file and the output format below.
+- Performance mode (`--performance` or performance-related trigger): Read and follow `references/performance-review.md`.
+- Security mode (`--security` or security-related trigger): Read and follow `references/security-review.md`.
+- When a focus mode is selected, keep the shared workflow above and use the matching checklist/output format from the referenced file.
+
+## Review Checklist
+
+### 1. Clarity & Purpose
+
+- What is this trying to accomplish? Summarize in one sentence.
+- Is the intent clear from reading the code?
+- Are names meaningful? Do variables, functions, and types describe their purpose?
+- Is the scope appropriate? Does each change do one thing well?
+
+### 2. Simplicity & Complexity
+
+- Could this be simpler? Look for unnecessary abstraction, indirection, or cleverness.
+- Is complexity justified? Does it solve a real problem that simple code cannot?
+- Are there unused or duplicate patterns? Flag anything that doesn't pull its weight.
+- Can logic be extracted? Look for repeated patterns that should be shared.
+
+### 3. Code Quality
+
+- Is it readable? Does the code flow naturally? Are functions appropriately sized?
+- Is it well-structured? Do files and directories make sense?
+- Does it follow existing patterns? Check consistency with the rest of the codebase.
+- Note: no linter is configured — review style manually against existing code conventions.
+- Vue-specific: Are reactive refs/computed used correctly? Is `watch` vs `watchEffect` appropriate?
+- Pinia-specific: Is store state mutated only inside actions? Are getters pure?
+
+### 4. Testing & Documentation
+
+- Is it well-tested? Are there tests for the new/changed behavior?
+- Do tests describe behavior? Tests should read like documentation.
+- Are tests broken? Broken tests = broken documentation. Flag immediately.
+- Are edge cases covered? Missing error handling or boundary conditions?
+- Run tests with `npm test` (frontend) or `cd functions && npm test` (backend).
+
+### 5. Security & Production Readiness
+
+- Are Firestore operations guarded by auth checks?
+- Are secrets protected? No tokens or keys in code.
+- Is error handling appropriate? Graceful failures with useful messages.
+- Are there performance concerns? Expensive Firestore reads, unsubscribed listeners.
+- Is it production-ready? Edge cases, failure modes, observability.
+
+### 6. Writing & Communication
+
+- Are commit messages concise? No jargon, clear intent.
+- Are comments direct? Say what you mean.
+- Avoid new ad-hoc ALL_CAPS doc files. Convention files (README, CLAUDE.md) are fine.
+
+### 7. Beyond the Checklist
+
+Look for things the checklist doesn't cover:
+
+- Are there better approaches? Different solutions, tradeoffs?
+- What patterns emerge? Repeated code suggesting a missing abstraction?
+- What might break? Edge cases, race conditions, failure modes?
+- How will this age? Easy to understand in 6 months? Easy to change?
+- What's missing? Logging, type safety, Firestore listener cleanup?
+- Are there ecosystem best practices not being followed?
+- What assumptions are being made? Are they documented and valid?
+
+Don't limit yourself to the checklist. If you see an issue, name it. If you see a better way, suggest it.
+
+Be direct.
+Flag real issues.
+Complexity is our enemy.
+
+## Output Format
+
+```markdown
+## Code Review: [branch name]
+
+### Summary
+[One sentence: what this branch does]
+
+### Architecture
+[How the change fits into the existing Vue/Pinia/Firebase structure. Call out any structural concerns.]
+
+### Clarity
+[Are names, intent, and scope clear?]
+
+### Simplicity
+[Is unnecessary complexity present? What could be cut?]
+
+### Quality
+[Readability, conventions, Vue/Pinia patterns.]
+
+### Testing
+[Test coverage, quality, gaps.]
+
+### Concerns
+[Real issues, ranked by severity. Include file and line.]
+
+### Strengths
+[What's done well and worth preserving.]
+
+### Opportunities
+[Non-blocking improvements for future consideration.]
+
+### Recommendations
+[Specific, actionable fixes prioritized by impact.]
+
+### Verdict
+**Approve** | **Approve with suggestions** | **Request changes**
+[One sentence rationale.]
+```

--- a/.claude/skills/code-review/references/performance-review.md
+++ b/.claude/skills/code-review/references/performance-review.md
@@ -1,0 +1,77 @@
+# Performance Review Reference
+
+Use this reference for performance-focused reviews.
+Run the shared workflow in `../SKILL.md` first.
+
+## Review Checklist
+
+### Firestore and Data Fetching
+
+- Are there N+1 Firestore read patterns (reads inside loops)?
+- Are queries using collection-group queries or subcollections appropriately?
+- Are large result sets paginated or limited?
+- Are real-time listeners unsubscribed when components unmount (memory/cost leak)?
+- Are batched writes used instead of individual `set`/`update` calls where possible?
+- Are Firestore reads cached in Pinia store instead of re-fetched on every component mount?
+
+### Vue Reactivity
+
+- Are expensive computations in `computed()` rather than re-computed in templates?
+- Are large lists rendered with `v-for` using stable `:key` values?
+- Are unnecessary re-renders caused by non-reactive data being made reactive?
+- Is `watchEffect` used where `watch` with a specific source would be cheaper?
+- Are components split to limit reactivity scope (avoid full-page re-renders)?
+
+### Algorithmic Complexity
+
+- Are there O(n²) or worse patterns that could be O(n) or O(n log n)?
+- Are data structures appropriate for the access patterns (hash lookups vs linear scans)?
+- Are there unnecessary repeated computations that could be memoized?
+- Are sort/filter operations on store getters computed once rather than per template render?
+
+### Memory and Resource Usage
+
+- Are large Firestore result sets held in memory indefinitely in stores?
+- Are Firestore listeners accumulated without cleanup (onSnapshot without unsubscribe)?
+- Are Chart.js instances destroyed before re-creating them?
+- Are event listeners added in `mounted` and removed in `unmounted`?
+
+### Network and I/O
+
+- Are independent Firestore reads parallelized with `Promise.all` instead of awaited sequentially?
+- Are responses filtered server-side (Firestore `where`) rather than client-side?
+- Are Firebase Cloud Function calls batched where possible?
+
+### Telegram Bot (Cloud Functions)
+
+- Are Firestore writes inside the webhook handler batched?
+- Are duplicate update checks (`markUpdateProcessed`) done before expensive logic?
+- Are Firestore reads inside the handler minimized (no redundant fetches)?
+- Are async operations parallelized where independent?
+
+## Output Format
+
+```markdown
+## Performance Review: [branch name]
+
+### Summary
+[One sentence: what this branch does and its performance-relevant characteristics]
+
+### Findings
+
+#### High Impact
+[Issues likely to cause visible latency or resource problems at expected scale.
+Include file, line, estimated impact, and a fix.]
+
+#### Medium Impact
+[Issues that will matter at higher scale or under load.]
+
+#### Low Impact
+[Minor inefficiencies worth noting for future optimization.]
+
+### Positive Patterns
+[Performance-conscious patterns already in the code worth preserving.]
+
+### Recommendations
+[Specific, actionable fixes, prioritized by expected impact.]
+```

--- a/.claude/skills/code-review/references/security-review.md
+++ b/.claude/skills/code-review/references/security-review.md
@@ -1,0 +1,79 @@
+# Security Review Reference
+
+Use this reference for security-focused reviews.
+Run the shared workflow in `../SKILL.md` first.
+
+## Review Checklist
+
+### Authentication and Authorization (Firebase)
+
+- Are Firestore operations guarded by Firebase Auth checks in the client (`userStore` auth state)?
+- Are `adminOnly` routes enforced both in `router.beforeEach()` and Firestore Security Rules?
+- Is guild access checked before exposing guild-scoped data?
+- Are there any paths where unauthenticated users can trigger writes?
+- Are Firestore Security Rules the last line of defense (not just client-side guards)?
+
+### Telegram Bot (Cloud Functions)
+
+- Is the incoming webhook request validated (correct Telegram token in the URL/header)?
+- Is user input from Telegram messages sanitized before use in Firestore queries or replies?
+- Are duplicate update checks (`markUpdateProcessed`) in place to prevent replay attacks?
+- Are session states validated before acting on them (e.g., bait choice, modifier flows)?
+- Is the webhook endpoint restricted to Telegram's IP ranges where possible?
+
+### Injection and Input Handling
+
+- Is user input validated before being written to Firestore?
+- Are Firestore document IDs derived from user input validated/sanitized?
+- Is output to Telegram messages escaped to prevent Markdown injection?
+- Are file paths or dynamic imports constructed from user input?
+
+### Secrets and Credentials
+
+- Are Firebase config values (API keys, project IDs) stored in environment variables or `.env` files not committed to git?
+- Are Telegram bot tokens stored in Firebase Functions config / Secret Manager, not hardcoded?
+- Are no secrets logged in Cloud Function output?
+
+### Data Protection
+
+- Is sensitive player data (e.g., guild info, treasury balances) scoped correctly in Firestore rules?
+- Is logging in Cloud Functions avoiding sensitive data (user IDs, amounts, tokens)?
+- Are admin-only Firestore collections protected by Security Rules, not just client-side checks?
+
+### Dependencies and Configuration
+
+- Are there known-vulnerable dependencies? Check with `npm audit` (root and `functions/`).
+- Is Firebase Hosting serving with appropriate security headers (check `firebase.json`)?
+- Is Firestore in production mode (not test mode with open rules)?
+- Are Cloud Functions deployed with minimum required IAM permissions?
+
+### Cryptography and Randomness
+
+- Are dice rolls (`dice.js`) using sufficiently random sources for the game's fairness requirements?
+- Are no custom crypto implementations present where standard libraries exist?
+
+## Output Format
+
+```markdown
+## Security Review: [branch name]
+
+### Summary
+[One sentence: what this branch does and its security-relevant surface area]
+
+### Findings
+
+#### Critical
+[Issues that could be exploited now. Include file, line, and a fix.]
+
+#### Warning
+[Issues that could become exploitable or violate security best practices.]
+
+#### Informational
+[Observations worth noting but not directly exploitable.]
+
+### No Issues Found
+[List areas reviewed where no issues were found, so coverage is clear.]
+
+### Recommendations
+[Specific, actionable fixes, prioritized by severity.]
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Frontend development
+npm run dev          # Vite dev server on port 5173
+npm run build        # Production build → dist/
+npm run preview      # Preview production build
+npm test             # Run frontend tests (Node native test runner)
+
+# Deploy
+npm run deploy-stage # Deploy to Firebase staging channel
+npm run deploy       # Deploy to Firebase production hosting
+
+# Backend (Cloud Functions)
+cd functions && npm test   # Run function tests
+firebase deploy --only functions  # Deploy Cloud Functions
+```
+
+To run a single test file: `node --test tests/path/to/file.test.js`
+
+## Architecture Overview
+
+This is a **Vue 3 + Firebase** app managing guild/island data for a tabletop RPG (D&D) campaign, with a companion **Telegram fishing bot** implemented as Firebase Cloud Functions.
+
+### Frontend (`src/`)
+
+- **Entry:** `main.js` wires up Vue, Pinia, Vuetify (Material Design), and Vue Router
+- **Routing:** `router/index.js` — 12+ routes, nested under `/islands/:islandId`. Guards use `requiresAuth` and `adminOnly` route meta, enforced in `router.beforeEach()`
+- **State:** 14 Pinia stores in `store/`, each owning one domain (island, treasury, religion, population, ships, buildings, donations, mage guild, etc.). Stores call Firestore directly via async actions
+- **Data layer:** `services/` handles Firestore reads/writes and real-time listeners (e.g., `cycleService.js`, `mageGuildService.js`)
+- **UI:** Vuetify components + custom Vue components in `components/` (cards, dialogs, tables, progress bars) and page views in `views/`
+- **Custom calendar:** `src/utils/faerun-date.js` uses the `faerun-date` package to represent dates in the Forgotten Realms calendar system
+
+### Backend (`functions/`)
+
+Single exported Cloud Function: `telegramWebhook` (POST handler).
+
+```
+functions/src/
+├── telegram/          # Webhook handlers, Telegram API client, reply helpers
+├── services/          # Firestore operations, fishing game logic
+├── utils/             # Input validation, D20 dice rolls
+└── config/constants.js
+```
+
+The fishing game uses D20 rolls + modifiers vs. a DC, bait selection, optional guidance re-roll, and per-day fish availability tracked in Firestore. Duplicate Telegram updates are deduplicated via Firestore before processing.
+
+### Key Domain Concepts
+
+- **Islands** — primary entity; most data is scoped to an island ID
+- **Treasury** — silver currency, transactions, chest management
+- **Religion** — faith tracking, distributions, donations (overflow logic)
+- **Crafting** — discount formulas by category/subcategory/specialization; progress per hero; item slugs as identifiers
+- **Fishing bot** — Telegram-driven mini-game with dice mechanics, bait, and daily resets
+
+## Conventions
+
+- Vue files: `PascalCase` (e.g., `IslandInfoPage.vue`, `TreasuryChestCard.vue`)
+- Pinia stores: camelCase + `Store` suffix (`treasuryStore`, `religionStore`)
+- Services: camelCase + `Service` suffix (`firestoreService`, `fishingService`)
+- No ESLint/Prettier configured — no linting step exists
+- Path alias `@/` resolves to `src/` (configured in `vite.config.mjs`)


### PR DESCRIPTION
## What changed

- **`CLAUDE.md`** — codebase guide for Claude Code: build/test/deploy commands, architecture overview (Vue 3 + Pinia + Firebase + Telegram bot), and naming conventions.
- **`.claude/commands/code-review.md`** — registers `/code-review` as a Claude Code slash command.
- **`.claude/skills/code-review/`** — skill backing the command with a general checklist and two focus-mode references:
  - `references/performance-review.md` — Firestore listener cleanup, Vue reactivity, Chart.js, Telegram bot patterns
  - `references/security-review.md` — Firebase Auth, Firestore Security Rules, Telegram webhook validation, secrets management

## Why

Sets up a baseline for AI-assisted development and code review, tailored to this project's stack.

## Notes

All changes are in `.claude/` (tooling) and `CLAUDE.md` (root doc) — no app code touched. No sensitive content from the source project was carried over.