### PR TITLE
Refactor: test coverage + kebab-case Firestore collection names

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,7 @@
+{
+  "projects": {
+    "west-islands": "west-islands-dnd"
+  },
+  "targets": {},
+  "etags": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ node_modules/
 /scripts/
 /.idea/codeStyles/codeStyleConfig.xml
 /.idea/codeStyles/Project.xml
+/backups/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,12 @@ The fishing game uses D20 rolls + modifiers vs. a DC, bait selection, optional g
 - **Crafting** — discount formulas by category/subcategory/specialization; progress per hero; item slugs as identifiers
 - **Fishing bot** — Telegram-driven mini-game with dice mechanics, bait, and daily resets
 
+## Firestore Schema
+
+All Firestore collection and document shapes are defined as JSDoc typedefs in [`src/types/firestore.js`](src/types/firestore.js).
+
+**This file is the source of truth for the database schema.** Whenever you add, rename, or remove a field in any Firestore collection — in a store, service, or Cloud Function — you must update the corresponding typedef in `src/types/firestore.js` in the same change. Never leave the typedefs stale.
+
 ## Conventions
 
 - Vue files: `PascalCase` (e.g., `IslandInfoPage.vue`, `TreasuryChestCard.vue`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
+        "firebase-admin": "^13.9.0",
         "vite": "^7.1.2",
         "vite-plugin-static-copy": "^3.1.1"
       }
@@ -485,6 +486,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@firebase/ai": {
       "version": "1.4.1",
@@ -1094,6 +1102,147 @@
       "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@google-cloud/firestore": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
@@ -1131,6 +1280,18 @@
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "license": "MIT"
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -1141,6 +1302,31 @@
       "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
       "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1155,9 +1341,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -1183,9 +1369,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1201,9 +1387,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1493,10 +1679,55 @@
         "win32"
       ]
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1508,6 +1739,28 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.1",
@@ -1658,6 +1911,30 @@
       "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
       "license": "MIT"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1696,6 +1973,67 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1729,6 +2067,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chart.js": {
@@ -1799,6 +2159,20 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/copy-anything": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
@@ -1820,11 +2194,101 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -1836,6 +2300,59 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1894,12 +2411,88 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/faerun-date": {
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/faerun-date/-/faerun-date-0.1.16.tgz",
       "integrity": "sha512-ThP/xkutI3e6C/VZ8PPi9f4laIRwJWO8qnRWiWcC6C+ZEo7QuDmEWw8u4hoecErHrTpBcMR7yyZWWUGm3xeJ4g==",
       "bin": {
         "faerun-compare-weeks": "bin/compare-weeks.js"
+      }
+    },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/faye-websocket": {
@@ -1912,6 +2505,30 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fill-range": {
@@ -1963,6 +2580,64 @@
         "@firebase/util": "1.12.1"
       }
     },
+    "node_modules/firebase-admin": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.9.0.tgz",
+      "integrity": "sha512-qiCVBBFH+kfLiCXuuE9eAbBQSckPuA43fbQ/MNvQfd9nZcHFQExmQICD/N0sZrNZDNy8FSywhjFzJJGVQzG5UA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "farmhash-modern": "^1.1.0",
+        "fast-deep-equal": "^3.1.1",
+        "google-auth-library": "^10.6.1",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0",
+        "node-forge": "^1.4.0",
+        "uuid": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
@@ -1993,6 +2668,108 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2000,6 +2777,47 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2015,6 +2833,204 @@
         "node": ">= 6"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2022,11 +3038,89 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
@@ -2034,11 +3128,63 @@
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2095,6 +3241,20 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-what": {
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
@@ -2105,6 +3265,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/jsonfile": {
@@ -2120,10 +3300,135 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
+      "dev": true
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/long": {
@@ -2131,6 +3436,30 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
@@ -2141,10 +3470,67 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2165,6 +3551,59 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2173,6 +3612,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
@@ -2186,6 +3664,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/perfect-debounce": {
@@ -2262,28 +3757,58 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -2306,6 +3831,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/rfdc": {
@@ -2374,6 +3926,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2390,6 +3955,36 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -2418,6 +4013,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/superjson": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
@@ -2428,6 +4045,69 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/tinyglobby": {
@@ -2488,6 +4168,14 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2508,6 +4196,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -2714,11 +4424,29 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -2743,6 +4471,18 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -2760,6 +4500,31 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -2768,6 +4533,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -2794,6 +4566,20 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test",
+    "test": "node --import ./tests/setup.js --test",
     "deploy-stage": "firebase hosting:channel:deploy staging",
     "deploy": "firebase deploy --only hosting"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",
+    "firebase-admin": "^13.9.0",
     "vite": "^7.1.2",
     "vite-plugin-static-copy": "^3.1.1"
   }

--- a/src/services/craftingService.ts
+++ b/src/services/craftingService.ts
@@ -8,7 +8,7 @@ import {
   runTransaction,
   serverTimestamp,
 } from 'firebase/firestore';
-import { db } from './firebase';
+import { db } from './firebase.js';
 import {
   applyCraftProgress,
   createDefaultItemProgress,
@@ -16,7 +16,7 @@ import {
   getSubcategoryKey,
   recalculateHeroCrafting,
   slugifyKey,
-} from '@/utils/crafting/craftingCalculations';
+} from '../utils/crafting/craftingCalculations.ts';
 
 function normalizeNumber(value: unknown, fallback = 0): number {
   const parsed = Number(value);
@@ -76,16 +76,24 @@ export function getEmptyCraftingState() {
   };
 }
 
-export async function registerCraftAction({ heroId, itemSlug, amountCrafted, craftItems, createdBy = null }: any) {
-  const heroRef = doc(db, 'heroes', heroId);
-  const logsRef = collection(db, 'heroes', heroId, 'craftingLogs');
+export async function registerCraftAction({ heroId, itemSlug, amountCrafted, craftItems, createdBy = null }: any, {
+  doc: docFn = doc,
+  collection: collectionFn = collection,
+  getDocs: getDocsFn = getDocs,
+  query: queryFn = query,
+  runTransaction: runTransactionFn = runTransaction,
+  serverTimestamp: serverTimestampFn = serverTimestamp,
+  db: firestoreDb = db,
+}: any = {}) {
+  const heroRef = docFn(firestoreDb, 'heroes', heroId);
+  const logsRef = collectionFn(firestoreDb, 'heroes', heroId, 'craftingLogs');
 
   const allItems = (craftItems?.length
     ? craftItems
-    : (await getDocs(query(collection(db, 'craftItems')))).docs.map((row) => normalizeCraftItem(row.data(), row.id))
+    : (await getDocsFn(queryFn(collectionFn(firestoreDb, 'craftItems')))).docs.map((row: any) => normalizeCraftItem(row.data(), row.id))
   ).filter((item: any) => item.isActive);
 
-  return runTransaction(db, async (transaction) => {
+  return runTransactionFn(firestoreDb, async (transaction: any) => {
     const heroDoc = await transaction.get(heroRef);
 
     if (!heroDoc.exists()) throw new Error('Hero not found');
@@ -125,12 +133,12 @@ export async function registerCraftAction({ heroId, itemSlug, amountCrafted, cra
         ...recalc,
         summary: {
           ...recalc.summary,
-          updatedAt: serverTimestamp(),
+          updatedAt: serverTimestampFn(),
         },
       },
     });
 
-    const logRef = doc(logsRef);
+    const logRef = docFn(logsRef);
     const totalComponentPriceAtTime = Number(item.componentPrice || 0) * Number(amountCrafted || 0);
 
     transaction.set(logRef, {
@@ -149,7 +157,7 @@ export async function registerCraftAction({ heroId, itemSlug, amountCrafted, cra
       categoryCappedReached: progressUpdate.categoryCappedReached,
       subcategoryCappedReached: progressUpdate.subcategoryCappedReached,
       specializationCappedReached: progressUpdate.specializationCappedReached,
-      createdAt: serverTimestamp(),
+      createdAt: serverTimestampFn(),
       createdBy,
     });
 

--- a/src/services/craftingService.ts
+++ b/src/services/craftingService.ts
@@ -45,7 +45,7 @@ export function normalizeCraftItem(raw: any, id = '') {
 }
 
 export async function loadCraftItems() {
-  const snapshot = await getDocs(query(collection(db, 'craftItems'), orderBy('name', 'asc')));
+  const snapshot = await getDocs(query(collection(db, 'craft-items'), orderBy('name', 'asc')));
   return snapshot.docs
     .map((docSnap) => normalizeCraftItem(docSnap.data(), docSnap.id))
     .filter((item) => item.isActive);
@@ -86,11 +86,11 @@ export async function registerCraftAction({ heroId, itemSlug, amountCrafted, cra
   db: firestoreDb = db,
 }: any = {}) {
   const heroRef = docFn(firestoreDb, 'heroes', heroId);
-  const logsRef = collectionFn(firestoreDb, 'heroes', heroId, 'craftingLogs');
+  const logsRef = collectionFn(firestoreDb, 'heroes', heroId, 'crafting-logs');
 
   const allItems = (craftItems?.length
     ? craftItems
-    : (await getDocsFn(queryFn(collectionFn(firestoreDb, 'craftItems')))).docs.map((row: any) => normalizeCraftItem(row.data(), row.id))
+    : (await getDocsFn(queryFn(collectionFn(firestoreDb, 'craft-items')))).docs.map((row: any) => normalizeCraftItem(row.data(), row.id))
   ).filter((item: any) => item.isActive);
 
   return runTransactionFn(firestoreDb, async (transaction: any) => {

--- a/src/services/cycleService.js
+++ b/src/services/cycleService.js
@@ -138,7 +138,7 @@ export async function distributeManufactureIncome(cycleId, startedAt, finishedAt
   if (!combinedEntries.length) return
 
   const metaRef = docFn(firestoreDb, 'treasury/meta')
-  const txCol = collectionFn(firestoreDb, 'treasuryTransactions')
+  const txCol = collectionFn(firestoreDb, 'treasury-transactions')
   const cycleLabel = formatCycleLabel(startedAt, finishedAt)
   const treasuryEntries = combinedEntries.filter((item) => item.type !== 'manufacture' || !item.incomeDestination?.startsWith('guild:'))
   const totalIncome = treasuryEntries.reduce((sum, item) => (item.income > 0 ? sum + item.income : sum), 0)
@@ -326,8 +326,8 @@ export async function createNewCycleWithEffects({
   }
 
   await resetReligionsSvTemp(sharedDeps)
-  await addDocFn(collectionFn(firestoreDb, 'religionActions'), {
-    actionType: docFn(firestoreDb, 'religionActionTypes', 'cycleStart'),
+  await addDocFn(collectionFn(firestoreDb, 'religion-actions'), {
+    actionType: docFn(firestoreDb, 'religion-action-types', 'cycleStart'),
     cycleId: cycleDoc.id,
     notes: notes?.trim() || '',
     createdAt: serverTimestampFn(),

--- a/src/services/cycleService.js
+++ b/src/services/cycleService.js
@@ -14,11 +14,17 @@ import {
   where,
   writeBatch,
 } from 'firebase/firestore'
-import { diffInDays, formatFaerunDate, normalizeFaerunDate, parseFaerunDate } from 'faerun-date'
-import { db } from '@/services/firebase'
-import { BUILDING_LEVEL_BONUSES } from '@/store/religionStore'
-import { formatAmount } from '@/utils/formatters'
-import { generateSpellRequestsForCycle, settlePreviousSpellRequests } from '@/services/mageGuildService'
+import { diffInDays, formatFaerunDate, normalizeFaerunDate, parseFaerunDate } from '../utils/faerun-date.js'
+import { db } from './firebase.js'
+import { formatAmount } from '../utils/formatters.js'
+import { generateSpellRequestsForCycle, settlePreviousSpellRequests } from './mageGuildService.js'
+
+const BUILDING_LEVEL_BONUSES = {
+  none: { passiveFaith: 0 },
+  chapel: { passiveFaith: 20 },
+  temple: { passiveFaith: 40 },
+  cathedral: { passiveFaith: 60 },
+}
 
 function normalizeAmount(value) {
   const parsed = Number(value)
@@ -43,19 +49,31 @@ function getBuildingFaithIncome(level) {
   return BUILDING_LEVEL_BONUSES[level]?.passiveFaith || 0
 }
 
-async function resetReligionsSvTemp() {
-  const religionsRef = collection(db, 'religions')
-  const religionsSnapshot = await getDocs(religionsRef)
+export async function resetReligionsSvTemp({
+  collection: collectionFn = collection,
+  getDocs: getDocsFn = getDocs,
+  writeBatch: writeBatchFn = writeBatch,
+  db: firestoreDb = db,
+} = {}) {
+  const religionsRef = collectionFn(firestoreDb, 'religions')
+  const religionsSnapshot = await getDocsFn(religionsRef)
   if (religionsSnapshot.empty) return
 
-  const batch = writeBatch(db)
-  religionsSnapshot.forEach((docSnap) => {
+  const batch = writeBatchFn(firestoreDb)
+  religionsSnapshot.docs.forEach((docSnap) => {
     batch.update(docSnap.ref, { svTemp: 0 })
   })
   await batch.commit()
 }
 
-async function loadManufacturesByIds(ids) {
+export async function loadManufacturesByIds(ids, {
+  collection: collectionFn = collection,
+  getDocs: getDocsFn = getDocs,
+  query: queryFn = query,
+  where: whereFn = where,
+  documentId: documentIdFn = documentId,
+  db: firestoreDb = db,
+} = {}) {
   if (!Array.isArray(ids) || ids.length === 0) return []
 
   const chunks = []
@@ -63,8 +81,8 @@ async function loadManufacturesByIds(ids) {
 
   const results = []
   for (const chunk of chunks) {
-    const q = query(collection(db, 'manufactures'), where(documentId(), 'in', chunk))
-    const snapshot = await getDocs(q)
+    const q = queryFn(collectionFn(firestoreDb, 'manufactures'), whereFn(documentIdFn(), 'in', chunk))
+    const snapshot = await getDocsFn(q)
     snapshot.docs.forEach((docSnap) => {
       const data = docSnap.data() || {}
       results.push({
@@ -82,12 +100,24 @@ async function loadManufacturesByIds(ids) {
   return results
 }
 
-async function distributeManufactureIncome(cycleId, startedAt, finishedAt, islandId, populationItems) {
-  const islandSnap = await getDoc(doc(db, 'islands', islandId || 'island_rock'))
+export async function distributeManufactureIncome(cycleId, startedAt, finishedAt, islandId, populationItems, {
+  collection: collectionFn = collection,
+  doc: docFn = doc,
+  getDoc: getDocFn = getDoc,
+  getDocs: getDocsFn = getDocs,
+  query: queryFn = query,
+  where: whereFn = where,
+  documentId: documentIdFn = documentId,
+  runTransaction: runTransactionFn = runTransaction,
+  serverTimestamp: serverTimestampFn = serverTimestamp,
+  db: firestoreDb = db,
+} = {}) {
+  const islandSnap = await getDocFn(docFn(firestoreDb, 'islands', islandId || 'island_rock'))
   if (!islandSnap.exists()) return
 
   const manufactureIds = Array.isArray(islandSnap.data()?.manufactures) ? islandSnap.data().manufactures : []
-  const entries = (await loadManufacturesByIds(manufactureIds)).filter((item) => item.income !== 0)
+  const loadDeps = { collection: collectionFn, getDocs: getDocsFn, query: queryFn, where: whereFn, documentId: documentIdFn, db: firestoreDb }
+  const entries = (await loadManufacturesByIds(manufactureIds, loadDeps)).filter((item) => item.income !== 0)
   const populationEntries = (populationItems || [])
     .map((group) => {
       const count = Number(group.count ?? group.amount ?? 0)
@@ -107,21 +137,21 @@ async function distributeManufactureIncome(cycleId, startedAt, finishedAt, islan
   const combinedEntries = [...entries.map((item) => ({ ...item, type: 'manufacture' })), ...populationEntries]
   if (!combinedEntries.length) return
 
-  const metaRef = doc(db, 'treasury/meta')
-  const txCol = collection(db, 'treasuryTransactions')
+  const metaRef = docFn(firestoreDb, 'treasury/meta')
+  const txCol = collectionFn(firestoreDb, 'treasuryTransactions')
   const cycleLabel = formatCycleLabel(startedAt, finishedAt)
   const treasuryEntries = combinedEntries.filter((item) => item.type !== 'manufacture' || !item.incomeDestination?.startsWith('guild:'))
   const totalIncome = treasuryEntries.reduce((sum, item) => (item.income > 0 ? sum + item.income : sum), 0)
   const totalOutcome = treasuryEntries.reduce((sum, item) => (item.income < 0 ? sum + Math.abs(item.income) : sum), 0)
 
-  await runTransaction(db, async (transaction) => {
+  await runTransactionFn(firestoreDb, async (transaction) => {
     const metaSnap = await transaction.get(metaRef)
     let currentBalance = metaSnap.exists() ? metaSnap.data()?.balance || 0 : 0
     const guildBalances = new Map()
     const guildIds = [...new Set(combinedEntries.filter((item) => item.type === 'manufacture' && item.incomeDestination?.startsWith('guild:')).map((item) => item.incomeDestination.slice('guild:'.length)).filter(Boolean))]
 
     await Promise.all(guildIds.map(async (guildId) => {
-      const guildRef = doc(db, 'guilds', guildId)
+      const guildRef = docFn(firestoreDb, 'guilds', guildId)
       const guildSnap = await transaction.get(guildRef)
       guildBalances.set(guildId, Number(guildSnap.exists() ? guildSnap.data()?.treasure || 0 : 0))
     }))
@@ -131,18 +161,18 @@ async function distributeManufactureIncome(cycleId, startedAt, finishedAt, islan
       const guildId = isGuildDestination ? item.incomeDestination.slice('guild:'.length) : null
 
       if (isGuildDestination && guildId) {
-        const guildRef = doc(db, 'guilds', guildId)
-        const guildLogsRef = collection(db, 'guilds', guildId, 'logs')
+        const guildRef = docFn(firestoreDb, 'guilds', guildId)
+        const guildLogsRef = collectionFn(firestoreDb, 'guilds', guildId, 'logs')
         const guildCurrent = Number(guildBalances.get(guildId) || 0)
         const guildNext = normalizeAmount(guildCurrent + item.income)
         guildBalances.set(guildId, guildNext)
-        transaction.set(guildRef, { treasure: guildNext, updatedAt: serverTimestamp() }, { merge: true })
-        transaction.set(doc(guildLogsRef), {
+        transaction.set(guildRef, { treasure: guildNext, updatedAt: serverTimestampFn() }, { merge: true })
+        transaction.set(docFn(guildLogsRef), {
           amount: item.income,
           type: item.income >= 0 ? 'deposit' : 'withdraw',
           comment: `Автооперація з мануфактури "${item.name || 'Без назви'}" за цикл ${cycleLabel}.`.slice(0, 500),
           userNickname: 'Система',
-          createdAt: serverTimestamp(),
+          createdAt: serverTimestampFn(),
           treasureAfter: guildNext,
         })
         continue
@@ -156,13 +186,13 @@ async function distributeManufactureIncome(cycleId, startedAt, finishedAt, islan
       if (item.type === 'manufacture' && item.description) commentParts.push(item.description)
       commentParts.push(`за цикл ${cycleLabel}.`)
 
-      transaction.set(doc(txCol), {
+      transaction.set(docFn(txCol), {
         amount: item.income,
         type: item.income >= 0 ? 'deposit' : 'withdraw',
         comment: commentParts.join(' ').slice(0, 500),
         userId: 'system',
         nickname: 'Система',
-        createdAt: serverTimestamp(),
+        createdAt: serverTimestampFn(),
         balanceAfter: currentBalance,
         cycleId,
         cycleStartedAt: startedAt,
@@ -174,13 +204,25 @@ async function distributeManufactureIncome(cycleId, startedAt, finishedAt, islan
       balance: currentBalance,
       totalIncome: normalizeAmount(totalIncome),
       totalOutcome: normalizeAmount(totalOutcome),
-      updatedAt: serverTimestamp(),
+      updatedAt: serverTimestampFn(),
     }, { merge: true })
   })
 }
 
-async function distributeBuildingFaithIncome(cycleId) {
-  const religionsSnapshot = await getDocs(collection(db, 'religions'))
+export async function distributeBuildingFaithIncome(cycleId, {
+  collection: collectionFn = collection,
+  doc: docFn = doc,
+  getDoc: getDocFn = getDoc,
+  getDocs: getDocsFn = getDocs,
+  query: queryFn = query,
+  where: whereFn = where,
+  addDoc: addDocFn = addDoc,
+  updateDoc: updateDocFn = updateDoc,
+  serverTimestamp: serverTimestampFn = serverTimestamp,
+  db: firestoreDb = db,
+  rng = Math.random,
+} = {}) {
+  const religionsSnapshot = await getDocsFn(collectionFn(firestoreDb, 'religions'))
   const religionsWithIncome = religionsSnapshot.docs
     .map((docSnap) => {
       const data = docSnap.data() || {}
@@ -190,7 +232,7 @@ async function distributeBuildingFaithIncome(cycleId) {
     .filter((religion) => religion.passiveFaith > 0)
 
   for (const religion of religionsWithIncome) {
-    const clergySnapshot = await getDocs(query(collection(db, 'clergy'), where('religion', '==', religion.ref)))
+    const clergySnapshot = await getDocsFn(queryFn(collectionFn(firestoreDb, 'clergy'), whereFn('religion', '==', religion.ref)))
     if (clergySnapshot.empty) continue
     const eligibilityChecks = await Promise.all(clergySnapshot.docs.map(async (docSnap) => {
       const data = docSnap.data() || {}
@@ -198,7 +240,7 @@ async function distributeBuildingFaithIncome(cycleId) {
       if (!heroRef) return { docSnap, eligible: true }
 
       try {
-        const heroSnap = await getDoc(heroRef)
+        const heroSnap = await getDocFn(heroRef)
         const heroData = heroSnap.exists() ? heroSnap.data() || {} : {}
         return { docSnap, eligible: heroData.passiveOVInactive !== true }
       } catch (error) {
@@ -211,7 +253,7 @@ async function distributeBuildingFaithIncome(cycleId) {
     if (!heroCount) continue
     const baseShare = Math.floor(religion.passiveFaith / heroCount)
     const remainder = religion.passiveFaith - baseShare * heroCount
-    const remainderIndex = remainder > 0 ? Math.floor(Math.random() * heroCount) : -1
+    const remainderIndex = remainder > 0 ? Math.floor(rng() * heroCount) : -1
 
     await Promise.all(eligible.map(async (docSnap, index) => {
       const bonus = baseShare + (index === remainderIndex ? remainder : 0)
@@ -220,15 +262,15 @@ async function distributeBuildingFaithIncome(cycleId) {
       const newFaith = Number(data.faith ?? 0) + bonus
       const updates = { faith: newFaith }
       if (Number(data.faithMax ?? 0) < newFaith) updates.faithMax = newFaith
-      await updateDoc(docSnap.ref, updates)
-      await addDoc(collection(docSnap.ref, 'logs'), {
+      await updateDocFn(docSnap.ref, updates)
+      await addDocFn(collectionFn(docSnap.ref, 'logs'), {
         delta: bonus,
         message: `Пасивний дохід від споруди (${religion.buildingLevel}) за цикл ${cycleId}.`,
         user: 'Система',
         cycleId,
         religionId: religion.id,
         religionName: religion.name,
-        createdAt: serverTimestamp(),
+        createdAt: serverTimestampFn(),
       })
     }))
   }
@@ -240,15 +282,34 @@ export async function createNewCycleWithEffects({
   islandId = 'island_rock',
   population = 0,
   populationItems = [],
-}) {
-  const normalizedStart = normalizeFaerunDate(startedDate)
+}, {
+  collection: collectionFn = collection,
+  doc: docFn = doc,
+  getDoc: getDocFn = getDoc,
+  getDocs: getDocsFn = getDocs,
+  addDoc: addDocFn = addDoc,
+  updateDoc: updateDocFn = updateDoc,
+  query: queryFn = query,
+  where: whereFn = where,
+  orderBy: orderByFn = orderBy,
+  limit: limitFn = limit,
+  serverTimestamp: serverTimestampFn = serverTimestamp,
+  db: firestoreDb = db,
+  rng = Math.random,
+  settlePreviousSpellRequestsFn = settlePreviousSpellRequests,
+  generateSpellRequestsForCycleFn = generateSpellRequestsForCycle,
+} = {}) {
+  const parsed = typeof startedDate === 'string' ? parseFaerunDate(startedDate) : startedDate
+  const normalizedStart = parsed ? normalizeFaerunDate(parsed) : null
   if (!normalizedStart) throw new Error('INVALID_START_DATE')
 
-  const cyclesRef = collection(db, 'cycles')
-  const lastCycleSnapshot = await getDocs(query(cyclesRef, orderBy('createdAt', 'desc'), limit(1)))
+  const sharedDeps = { collection: collectionFn, doc: docFn, getDoc: getDocFn, getDocs: getDocsFn, addDoc: addDocFn, updateDoc: updateDocFn, query: queryFn, where: whereFn, serverTimestamp: serverTimestampFn, db: firestoreDb, rng }
+
+  const cyclesRef = collectionFn(firestoreDb, 'cycles')
+  const lastCycleSnapshot = await getDocsFn(queryFn(cyclesRef, orderByFn('createdAt', 'desc'), limitFn(1)))
   const lastCycleDoc = lastCycleSnapshot.docs[0]
   const startedAt = formatFaerunDate(normalizedStart)
-  const cycleDoc = await addDoc(cyclesRef, { startedAt, createdAt: serverTimestamp() })
+  const cycleDoc = await addDocFn(cyclesRef, { startedAt, createdAt: serverTimestampFn() })
 
   if (lastCycleDoc && !lastCycleDoc.data().finishedAt) {
     const previousCycle = lastCycleDoc.data()
@@ -261,22 +322,22 @@ export async function createNewCycleWithEffects({
     }
     const previousUpdate = { finishedAt: formatFaerunDate(previousFinishedDate) }
     if (previousDuration && previousDuration > 0) previousUpdate.duration = previousDuration
-    await updateDoc(lastCycleDoc.ref, previousUpdate)
+    await updateDocFn(lastCycleDoc.ref, previousUpdate)
   }
 
-  await resetReligionsSvTemp()
-  await addDoc(collection(db, 'religionActions'), {
-    actionType: doc(db, 'religionActionTypes', 'cycleStart'),
+  await resetReligionsSvTemp(sharedDeps)
+  await addDocFn(collectionFn(firestoreDb, 'religionActions'), {
+    actionType: docFn(firestoreDb, 'religionActionTypes', 'cycleStart'),
     cycleId: cycleDoc.id,
     notes: notes?.trim() || '',
-    createdAt: serverTimestamp(),
+    createdAt: serverTimestampFn(),
     convertedFollowers: 0,
     result: 0,
   })
-  await distributeBuildingFaithIncome(cycleDoc.id)
-  await distributeManufactureIncome(cycleDoc.id, startedAt, null, islandId, populationItems)
-  await settlePreviousSpellRequests()
-  await generateSpellRequestsForCycle({
+  await distributeBuildingFaithIncome(cycleDoc.id, sharedDeps)
+  await distributeManufactureIncome(cycleDoc.id, startedAt, null, islandId, populationItems, sharedDeps)
+  await settlePreviousSpellRequestsFn()
+  await generateSpellRequestsForCycleFn({
     cycleRef: cycleDoc,
     cycleId: cycleDoc.id,
     islandId,

--- a/src/services/mageGuildService.js
+++ b/src/services/mageGuildService.js
@@ -140,7 +140,7 @@ async function resolvePopulation(islandId, fallbackPopulation) {
 }
 
 export function subscribeSpellRequests(callback, onError) {
-  const q = query(collection(db, 'spellRequests'), orderBy('createdAt', 'desc'))
+  const q = query(collection(db, 'spell-requests'), orderBy('createdAt', 'desc'))
   const cycleCache = new Map()
 
   return onSnapshot(q, async (snapshot) => {
@@ -210,7 +210,7 @@ export async function fetchLatestCycle() {
 export async function settlePreviousSpellRequests() {
   const [config, spellRequestsSnapshot, spellsSnapshot] = await Promise.all([
     fetchMageGuildConfig(),
-    getDocs(collection(db, 'spellRequests')),
+    getDocs(collection(db, 'spell-requests')),
     getDocs(collection(db, 'spells')),
   ])
 
@@ -311,7 +311,7 @@ export async function generateSpellRequestsForCycle({
     spells,
   })
 
-  const spellRequestsRef = collection(db, 'spellRequests')
+  const spellRequestsRef = collection(db, 'spell-requests')
   const spellRequestDoc = await addDoc(spellRequestsRef, {
     cycle: cycleRef,
     cycleId,
@@ -335,7 +335,7 @@ export async function generateSpellRequestsForCycle({
 
 export async function ensureCurrentCycleSpellRequests({ islandId, population, createdBy = '' }) {
   const latestCycle = await fetchLatestCycle()
-  const requestSnapshot = await getDocs(collection(db, 'spellRequests'))
+  const requestSnapshot = await getDocs(collection(db, 'spell-requests'))
   const existingDoc = requestSnapshot.docs.find((docSnap) => {
     const data = docSnap.data() || {}
     return !data.isTest && data.cycleId === latestCycle.id
@@ -378,7 +378,7 @@ export async function fulfillSpellRequest({
   if (!requestId) throw new Error('Не вказано заявку.')
   if (!heroId) throw new Error('Оберіть героя.')
 
-  const requestRef = doc(db, 'spellRequests', spellRequestId)
+  const requestRef = doc(db, 'spell-requests', spellRequestId)
   const heroRef = doc(db, HERO_COLLECTION, heroId)
 
   await runTransaction(db, async (transaction) => {

--- a/src/services/mageGuildService.js
+++ b/src/services/mageGuildService.js
@@ -13,7 +13,7 @@ import {
   serverTimestamp,
   updateDoc,
 } from 'firebase/firestore'
-import { db } from '@/services/firebase'
+import { db } from './firebase.js'
 import {
   applySpellPriceDelta,
   buildSpellRequestDrafts,
@@ -22,7 +22,7 @@ import {
   getSpellPrice,
   getSpellTier,
   normalizeSpellLevel,
-} from '@/utils/mageGuildRequests'
+} from '../utils/mageGuildRequests.js'
 
 const SPELL_REQUEST_CONFIG_ID = 'spell-request-prices'
 const HERO_COLLECTION = 'heroes'

--- a/src/store/courierLogStore.js
+++ b/src/store/courierLogStore.js
@@ -6,7 +6,7 @@ export const useCourierLogStore = defineStore('courierLogStore', {
     actions: {
         async addLog({history = '', distance = 'N/A', conSaveMod = 'N/A', speed = 'N/A', dangerChance = 'N/A', character = 'N/A', success = false}) {
             try {
-                await addDoc(collection(db, 'courierLogs'), {
+                await addDoc(collection(db, 'courier-logs'), {
                     timestamp: new Date(),
                     history,
                     distance,

--- a/src/store/donationGoalStore.js
+++ b/src/store/donationGoalStore.js
@@ -14,14 +14,14 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/services/firebase';
 
-export const useDonationGoalStore = defineStore('donationGoals', () => {
+export const useDonationGoalStore = defineStore('donation-goals', () => {
     const goals = ref([])
     let _unsub = null
 
     // === Realtime goals ===
     function subscribeToGoals() {
         if (_unsub) return _unsub
-        const colRef = collection(db, 'donationGoals')
+        const colRef = collection(db, 'donation-goals')
         _unsub = onSnapshot(colRef, (snapshot) => {
             goals.value = snapshot.docs.map(d => {
                 const data = d.data()
@@ -63,18 +63,18 @@ export const useDonationGoalStore = defineStore('donationGoals', () => {
         }
 
         if (goal.id) {
-            await updateDoc(doc(db, 'donationGoals', goal.id), data)
+            await updateDoc(doc(db, 'donation-goals', goal.id), data)
         } else {
-            await addDoc(collection(db, 'donationGoals'), data)
+            await addDoc(collection(db, 'donation-goals'), data)
         }
     }
 
     async function deleteGoal(id) {
-        await deleteDoc(doc(db, 'donationGoals', id))
+        await deleteDoc(doc(db, 'donation-goals', id))
     }
 
     async function toggleVisibility(goal) {
-        const refDoc = doc(db, 'donationGoals', goal.id)
+        const refDoc = doc(db, 'donation-goals', goal.id)
         await updateDoc(refDoc, { visible: !goal.visible })
     }
 
@@ -93,7 +93,7 @@ export const useDonationGoalStore = defineStore('donationGoals', () => {
         if (!goalId) throw new Error('goalId is required')
         if (!amount || amount <= 0) throw new Error('Некоректна сума')
 
-        const goalRef = doc(db, 'donationGoals', goalId)
+        const goalRef = doc(db, 'donation-goals', goalId)
         const goalSnap = await getDoc(goalRef)
         if (!goalSnap.exists()) throw new Error('Ціль не знайдено')
 
@@ -131,7 +131,7 @@ export const useDonationGoalStore = defineStore('donationGoals', () => {
 
     async function toggleLockGoal(id, status) {
         if (!id) throw new Error('id is required')
-        await updateDoc(doc(db, 'donationGoals', id), { status })
+        await updateDoc(doc(db, 'donation-goals', id), { status })
     }
 
     return {

--- a/src/store/guildStore.js
+++ b/src/store/guildStore.js
@@ -13,6 +13,45 @@ import {
   setDoc,
 } from 'firebase/firestore';
 
+// Exported for testing. Applies a guild deposit or withdrawal atomically.
+export async function applyGuildTransaction(
+  { guildId, amount, comment, actor, type },
+  {
+    runTransactionFn = runTransaction,
+    docFn = doc,
+    collectionFn = collection,
+    serverTimestampFn = serverTimestamp,
+    db: firestoreDb,
+  } = {},
+) {
+  const db = firestoreDb ?? getFirestore();
+  const guildRef = docFn(db, 'guilds', guildId);
+  const logsRef = collectionFn(db, 'guilds', guildId, 'logs');
+
+  await runTransactionFn(db, async (t) => {
+    const guildSnap = await t.get(guildRef);
+    if (!guildSnap.exists()) throw new Error('Guild not found.');
+
+    const guildData = guildSnap.data() || {};
+    const currentTreasure = Number(guildData.treasure || 0);
+    const nextTreasure = roundAmount(currentTreasure + amount);
+
+    if (nextTreasure < 0) throw new Error('Not enough guild treasure for this withdrawal.');
+
+    t.set(guildRef, { treasure: nextTreasure, updatedAt: serverTimestampFn() }, { merge: true });
+
+    const logRef = docFn(logsRef);
+    t.set(logRef, {
+      amount,
+      type,
+      comment: (comment || '').slice(0, 500),
+      userNickname: (actor?.nickname || 'Unknown').slice(0, 80),
+      createdAt: serverTimestampFn(),
+      treasureAfter: nextTreasure,
+    });
+  });
+}
+
 export const useGuildStore = defineStore('guilds', {
   state: () => ({
     guilds: [],
@@ -99,43 +138,7 @@ export const useGuildStore = defineStore('guilds', {
     },
 
     async _applyTransaction({ guildId, amount, comment, actor, type }) {
-      const db = getFirestore();
-      const guildRef = doc(db, 'guilds', guildId);
-      const logsRef = collection(db, 'guilds', guildId, 'logs');
-
-      await runTransaction(db, async (t) => {
-        const guildSnap = await t.get(guildRef);
-        if (!guildSnap.exists()) {
-          throw new Error('Guild not found.');
-        }
-
-        const guildData = guildSnap.data() || {};
-        const currentTreasure = Number(guildData.treasure || 0);
-        const nextTreasure = roundAmount(currentTreasure + amount);
-
-        if (nextTreasure < 0) {
-          throw new Error('Not enough guild treasure for this withdrawal.');
-        }
-
-        t.set(
-          guildRef,
-          {
-            treasure: nextTreasure,
-            updatedAt: serverTimestamp(),
-          },
-          { merge: true },
-        );
-
-        const logRef = doc(logsRef);
-        t.set(logRef, {
-          amount,
-          type,
-          comment: (comment || '').slice(0, 500),
-          userNickname: (actor?.nickname || 'Unknown').slice(0, 80),
-          createdAt: serverTimestamp(),
-          treasureAfter: nextTreasure,
-        });
-      });
+      await applyGuildTransaction({ guildId, amount, comment, actor, type });
     },
   },
 });

--- a/src/store/interestGroupStore.js
+++ b/src/store/interestGroupStore.js
@@ -30,7 +30,7 @@ export const useInterestGroupStore = defineStore('interestGroup', () => {
         const db = getFirestore()
 
         // 1) interestGroup по islandId (якщо задано) або вся колекція
-        const refGroups = collection(db, 'interestGroup')
+        const refGroups = collection(db, 'interest-groups')
         const qGroups = islandId
             ? query(refGroups, where('islandId', '==', islandId), orderBy('name'))
             : query(refGroups, orderBy('name'))

--- a/src/store/religionStore.js
+++ b/src/store/religionStore.js
@@ -142,7 +142,7 @@ export const useReligionStore = defineStore('religion', () => {
 
     const colRef = collection(db, 'clergy')
     const religionsRef = collection(db, 'religions')
-    const abilitiesRef = collection(db, 'religionsAbilities')
+    const abilitiesRef = collection(db, 'religion-abilities')
     const heroCache = new Map()
     const religionCache = new Map()
 

--- a/src/store/treasuryStore.js
+++ b/src/store/treasuryStore.js
@@ -4,6 +4,44 @@ import {
     getDocs, onSnapshot, runTransaction, serverTimestamp
 } from "firebase/firestore";
 
+// Exported for testing. Accepts injectable firebase deps so the transaction
+// logic can be verified without a real Firestore connection.
+export async function applyTreasuryTransaction(
+    { delta, type, comment, user },
+    {
+        runTransactionFn = runTransaction,
+        docFn = doc,
+        collectionFn = collection,
+        serverTimestampFn = serverTimestamp,
+        db: firestoreDb,
+    } = {},
+) {
+    const db = firestoreDb ?? getFirestore();
+    const metaRef = docFn(db, "treasury/meta");
+    const txCol = collectionFn(db, "treasuryTransactions");
+
+    await runTransactionFn(db, async (t) => {
+        const metaSnap = await t.get(metaRef);
+        const metaData = metaSnap.exists() ? metaSnap.data() : {};
+        const current = metaData.balance || 0;
+        const newBalance = current + delta;
+
+        if (newBalance < 0) throw new Error("Недостатньо золота у скарбниці.");
+
+        const txRef = docFn(txCol);
+        t.set(txRef, {
+            amount: delta,
+            type,
+            comment: (comment || "").slice(0, 500),
+            userId: user?.uid || "anon",
+            nickname: (user?.nickname || "Гравець").slice(0, 80),
+            createdAt: serverTimestampFn(),
+            balanceAfter: newBalance,
+        });
+        t.set(metaRef, { balance: newBalance, updatedAt: serverTimestampFn() }, { merge: true });
+    });
+}
+
 export const useTreasuryStore = defineStore("treasury", {
     state: () => ({
         balance: 0,
@@ -76,40 +114,8 @@ export const useTreasuryStore = defineStore("treasury", {
             } finally { this.loading = false; }
         },
 
-        // Внутрішня утиліта: атомарна операція
         async _applyTx({ delta, type, comment, user }) {
-            const db = getFirestore();
-            const metaRef = doc(db, "treasury/meta");
-            const txCol = collection(db, "treasuryTransactions");
-
-            await runTransaction(db, async (t) => {
-                // 1) читаємо поточний баланс
-                const metaSnap = await t.get(metaRef);
-                const metaData = metaSnap.exists() ? metaSnap.data() : {};
-                const current = metaData.balance || 0;
-
-                const newBalance = current + delta;
-                if (newBalance < 0) {
-                    throw new Error("Недостатньо золота у скарбниці.");
-                }
-                // 2) створюємо запис транзакції
-                const txRef = doc(txCol); // авто-ID
-                t.set(txRef, {
-                    amount: delta,                   // +для внеску, –для зняття
-                    type,                            // "deposit"|"withdraw"
-                    comment: (comment || "").slice(0, 500),
-                    userId: user?.uid || "anon",
-                    nickname: (user?.nickname || "Гравець").slice(0, 80),
-                    createdAt: serverTimestamp(),
-                    balanceAfter: newBalance
-                });
-
-                // 3) оновлюємо баланс
-                t.set(metaRef, {
-                    balance: newBalance,
-                    updatedAt: serverTimestamp()
-                }, { merge: true });
-            });
+            await applyTreasuryTransaction({ delta, type, comment, user });
         },
 
         // Публічні методи

--- a/src/store/treasuryStore.js
+++ b/src/store/treasuryStore.js
@@ -18,7 +18,7 @@ export async function applyTreasuryTransaction(
 ) {
     const db = firestoreDb ?? getFirestore();
     const metaRef = docFn(db, "treasury/meta");
-    const txCol = collectionFn(db, "treasuryTransactions");
+    const txCol = collectionFn(db, "treasury-transactions");
 
     await runTransactionFn(db, async (t) => {
         const metaSnap = await t.get(metaRef);
@@ -83,7 +83,7 @@ export const useTreasuryStore = defineStore("treasury", {
             try {
                 const db = getFirestore();
                 const q = query(
-                    collection(db, "treasuryTransactions"),
+                    collection(db, "treasury-transactions"),
                     orderBy("createdAt", "desc"),
                     limit(this._pageSize)
                 );
@@ -101,7 +101,7 @@ export const useTreasuryStore = defineStore("treasury", {
             try {
                 const db = getFirestore();
                 const q = query(
-                    collection(db, "treasuryTransactions"),
+                    collection(db, "treasury-transactions"),
                     orderBy("createdAt", "desc"),
                     startAfter(this._lastDoc),
                     limit(this._pageSize)

--- a/src/types/firestore.js
+++ b/src/types/firestore.js
@@ -1,0 +1,490 @@
+/**
+ * Firestore schema type definitions (JSDoc).
+ *
+ * This file is the source of truth for Firestore document shapes.
+ * Update it whenever you add, rename, or remove fields in any collection.
+ * Collections are grouped by domain.
+ */
+
+// ─── ISLANDS ────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} IslandDoc
+ * @property {Record<string, BuildingEntry>} buildings - Map of building key → building state
+ * @property {number} buildingDiscount - Cost discount multiplier (0–1)
+ * @property {string[]} manufactures - Array of manufacture document IDs
+ */
+
+/**
+ * @typedef {Object} BuildingEntry
+ * @property {boolean} built - Whether the building has been constructed
+ */
+
+// ─── BUILDINGS ───────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} BuildingDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {number} cost
+ */
+
+// ─── POPULATION ──────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} PopulationDoc
+ * @property {string} id
+ * @property {string} islandId
+ * @property {string} name
+ * @property {number} count
+ * @property {number} incomePerPerson
+ * @property {string} description
+ */
+
+// ─── INTEREST GROUPS ─────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} InterestGroupDoc
+ * @property {string} id
+ * @property {string} islandId
+ * @property {string} name
+ * @property {number} count
+ */
+
+// ─── SHIPS ───────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} ShipDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {string} type
+ * @property {string} speedUnit
+ * @property {number} capacity
+ * @property {boolean} visible
+ */
+
+// ─── TREASURY ─────────────────────────────────────────────────────────────────
+
+/**
+ * Singleton document at `treasury/meta`.
+ * @typedef {Object} TreasuryMetaDoc
+ * @property {number} balance
+ * @property {number} totalIncome
+ * @property {number} totalOutcome
+ * @property {import('firebase/firestore').Timestamp} updatedAt
+ */
+
+/**
+ * Collection: `treasuryTransactions/{txId}`
+ * @typedef {Object} TreasuryTransactionDoc
+ * @property {string} id
+ * @property {number} amount - Positive for deposits, negative for withdrawals
+ * @property {'deposit'|'withdraw'} type
+ * @property {string} comment
+ * @property {string} userId - Firebase UID, 'anon', or 'system'
+ * @property {string} nickname
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ * @property {number} balanceAfter
+ * @property {string} cycleId
+ * @property {string} cycleStartedAt - Faerun date string
+ * @property {string|null} cycleFinishedAt - Faerun date string or null if cycle is open
+ */
+
+// ─── GUILDS ──────────────────────────────────────────────────────────────────
+
+/**
+ * Collection: `guilds/{guildId}`
+ * @typedef {Object} GuildDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {string} shortName
+ * @property {string} leader
+ * @property {number} treasure
+ * @property {boolean} visibleToAll
+ * @property {string} withdrawUsername
+ * @property {string} withdrawPassword
+ * @property {string} leaderPassword
+ * @property {Record<string, unknown>} assets
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ * @property {import('firebase/firestore').Timestamp} updatedAt
+ */
+
+/**
+ * Subcollection: `guilds/{guildId}/logs/{logId}`
+ * @typedef {Object} GuildLogDoc
+ * @property {string} id
+ * @property {number} amount
+ * @property {'deposit'|'withdraw'} type
+ * @property {string} comment
+ * @property {string} userNickname
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ * @property {number} treasureAfter
+ */
+
+// ─── RELIGION ────────────────────────────────────────────────────────────────
+
+/**
+ * Collection: `religions/{religionId}`
+ * @typedef {Object} ReligionDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {number} followers
+ * @property {'none'|'chapel'|'temple'|'cathedral'} buildingLevel
+ * @property {string|null} buildingUpdatedAt - Faerun date string
+ * @property {number} buildingFaithIncome
+ * @property {number} farmBase
+ * @property {number} farmDCBase
+ * @property {number} minSpreadFollowers
+ * @property {boolean} shieldActive
+ * @property {number} shieldBonus
+ * @property {number} svBase
+ * @property {number} svTemp
+ * @property {string[]} abilities - Array of religionsAbilities document IDs
+ * @property {Record<string, unknown>} milestoneAbilities
+ */
+
+/**
+ * Collection: `religionsAbilities/{abilityId}`
+ * @typedef {Object} ReligionAbilityDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {string} description
+ */
+
+/**
+ * Collection: `clergy/{clergyId}`
+ * @typedef {Object} ClergyDoc
+ * @property {string} id
+ * @property {import('firebase/firestore').DocumentReference} hero - Ref to heroes/{heroId}
+ * @property {import('firebase/firestore').DocumentReference} religion - Ref to religions/{religionId}
+ * @property {number} faith
+ * @property {number} faithMax
+ * @property {number} celestialFaith
+ * @property {number} sharedFaith
+ * @property {number} celestialTransferred
+ * @property {number} celestialGenerated
+ * @property {string} selectedCelestialBonus
+ * @property {boolean} inactive
+ * @property {boolean} downtimeAvailable
+ */
+
+/**
+ * Subcollection: `clergy/{clergyId}/logs/{logId}`
+ * @typedef {Object} ClergyLogDoc
+ * @property {number} delta - Positive or negative faith change
+ * @property {string} message
+ * @property {string} user - Nickname of user who made the change
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ */
+
+/**
+ * Collection: `religionActions/{actionId}`
+ * @typedef {Object} ReligionActionDoc
+ * @property {import('firebase/firestore').DocumentReference} actionType - Ref to religionActionTypes
+ * @property {string} cycleId
+ * @property {string} notes
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ * @property {number} convertedFollowers
+ * @property {number} result
+ */
+
+// ─── DONATIONS ───────────────────────────────────────────────────────────────
+
+/**
+ * Collection: `donationGoals/{goalId}`
+ * @typedef {Object} DonationGoalDoc
+ * @property {string} id
+ * @property {string} title
+ * @property {string} description
+ * @property {number} target
+ * @property {number} collected
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ * @property {string} createdBy
+ * @property {string} type
+ * @property {string|null} targetBuildingKey
+ * @property {boolean} visible
+ * @property {'open'|'locked'|'closed'} status
+ * @property {boolean} treasury
+ */
+
+/**
+ * Collection: `donations/{donationId}`
+ * @typedef {Object} DonationDoc
+ * @property {string} id
+ * @property {string} goalId
+ * @property {number} amount
+ * @property {string|null} character
+ * @property {import('firebase/firestore').Timestamp} donatedAt
+ */
+
+// ─── CYCLES ──────────────────────────────────────────────────────────────────
+
+/**
+ * Collection: `cycles/{cycleId}`
+ * @typedef {Object} CycleDoc
+ * @property {string} id
+ * @property {string} startedAt - Faerun date string
+ * @property {string|null} finishedAt - Faerun date string, null if cycle is open
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ */
+
+// ─── MANUFACTURES ────────────────────────────────────────────────────────────
+
+/**
+ * Collection: `manufactures/{manufactureId}`
+ * @typedef {Object} ManufactureDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {string} description
+ * @property {number} income
+ * @property {string} incomeDestination - 'treasury' or 'guild:{guildId}'
+ */
+
+// ─── HEROES & CRAFTING ───────────────────────────────────────────────────────
+
+/**
+ * Collection: `heroes/{heroId}`
+ * @typedef {Object} HeroDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} inactive
+ * @property {boolean} passiveOVInactive
+ * @property {boolean} downtimeAvailable
+ * @property {HeroCraftingData} crafting
+ */
+
+/**
+ * @typedef {Object} HeroCraftingData
+ * @property {HeroCraftingSummary} summary
+ * @property {Record<string, HeroItemProgress>} itemProgress - Keyed by item slug
+ * @property {Record<string, number>} categoryProgress - Keyed by category key
+ * @property {Record<string, number>} subcategoryProgress - Keyed by subcategory key
+ */
+
+/**
+ * @typedef {Object} HeroCraftingSummary
+ * @property {number} totalCraftActions
+ * @property {number} totalItemsCrafted
+ * @property {import('firebase/firestore').Timestamp} updatedAt
+ */
+
+/**
+ * @typedef {Object} HeroItemProgress
+ * @property {number} category
+ * @property {number} subcategory
+ * @property {number} specialization
+ * @property {import('firebase/firestore').Timestamp} updatedAt
+ */
+
+/**
+ * Subcollection: `heroes/{heroId}/craftingLogs/{logId}`
+ * @typedef {Object} CraftingLogDoc
+ * @property {string} id
+ * @property {string} itemSlug
+ * @property {string} itemName
+ * @property {number} amountCrafted
+ * @property {number} componentPriceAtTime
+ * @property {number} totalComponentPriceAtTime
+ * @property {number} categoryBefore
+ * @property {number} categoryAfter
+ * @property {number} subcategoryBefore
+ * @property {number} subcategoryAfter
+ * @property {number} specializationBefore
+ * @property {number} specializationAfter
+ * @property {boolean} categoryCappedReached
+ * @property {boolean} subcategoryCappedReached
+ * @property {boolean} specializationCappedReached
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ * @property {string} createdBy
+ */
+
+/**
+ * Collection: `craftItems/{itemSlug}`
+ * @typedef {Object} CraftItemDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {string} category
+ * @property {string} subcategory
+ * @property {string} categoryKey
+ * @property {string} subcategoryKey
+ * @property {number} componentPrice
+ * @property {number|null} weight
+ * @property {number} craftDays
+ * @property {number} dc
+ * @property {boolean} isActive
+ */
+
+// ─── MAGE GUILD ──────────────────────────────────────────────────────────────
+
+/**
+ * Collection: `spellRequests/{requestId}`
+ * @typedef {Object} SpellRequestDoc
+ * @property {string} id
+ * @property {import('firebase/firestore').DocumentReference} cycle - Ref to cycles/{cycleId}
+ * @property {string} cycleId
+ * @property {string} cycleStartedAt
+ * @property {string} cycleFinishedAt
+ * @property {string} cycleLabel
+ * @property {string} islandId
+ * @property {number} population
+ * @property {number} requestsMin
+ * @property {number} requestsMax
+ * @property {number} rolledRequestsCount
+ * @property {number} requestsCount
+ * @property {SpellRequestItem[]} requests
+ * @property {import('firebase/firestore').Timestamp} createdAt
+ * @property {import('firebase/firestore').Timestamp} updatedAt
+ * @property {string} createdBy
+ * @property {import('firebase/firestore').Timestamp|null} priceChangesAppliedAt
+ * @property {boolean} isTest
+ */
+
+/**
+ * @typedef {Object} SpellRequestItem
+ * @property {string} localId
+ * @property {string} spellId
+ * @property {string} spellName
+ * @property {string} spellLevel
+ * @property {number} compensation
+ * @property {number} downtimeDays
+ * @property {boolean} fulfilled
+ * @property {import('firebase/firestore').Timestamp|null} fulfilledAt
+ * @property {string} fulfilledByHeroId
+ * @property {string} fulfilledByHeroName
+ * @property {string} fulfilledByHeroRefPath
+ * @property {string} telegramPostUrl
+ * @property {string} updatedBy
+ */
+
+/**
+ * Collection: `spells/{spellId}`
+ * @typedef {Object} SpellDoc
+ * @property {string} id
+ * @property {string} name
+ * @property {string} spellLevel
+ * @property {string} spellTier
+ * @property {number} currentPrice
+ * @property {SpellRequestHistoryEntry[]} requestHistory
+ * @property {import('firebase/firestore').Timestamp} updatedAt
+ */
+
+/**
+ * @typedef {Object} SpellRequestHistoryEntry
+ * @property {string} requestId
+ * @property {string} spellRequestId
+ * @property {string} cycleId
+ * @property {string} fulfilledAt
+ * @property {string} heroId
+ * @property {string} heroName
+ * @property {string} telegramPostUrl
+ * @property {string} spellName
+ * @property {number} compensation
+ * @property {number} downtimeDays
+ * @property {import('firebase/firestore').Timestamp} recordedAt
+ */
+
+// ─── AUTH ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Singleton document at `credentials/admin`
+ * @typedef {Object} CredentialsAdminDoc
+ * @property {string} password
+ */
+
+// ─── LOGS ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Collection: `logs/{logId}`
+ * @typedef {Object} LogDoc
+ * @property {string} action
+ * @property {string} user
+ * @property {import('firebase/firestore').Timestamp} timestamp
+ * @property {string} type
+ * @property {string} [goalId]
+ * @property {string} [goalTitle]
+ * @property {number} [amount]
+ */
+
+// ─── FISHING BOT (Cloud Functions) ───────────────────────────────────────────
+
+/**
+ * Singleton document at `bot-configs/fishing`
+ * @typedef {Object} BotFishingConfigDoc
+ * @property {{ min: number, max: number }} modifierLimits
+ * @property {{ mainCatch: number, additionalCheckDc: number, eachRollDc: number }} dc
+ * @property {Array<{ minSum: number, quantity: number }>} quantityRules
+ * @property {{ enabled: boolean, diceSides: number, applyTo: string }} guidance
+ * @property {{ basic: BaitConfig, simple: BaitConfig, advanced: BaitConfig }} bait
+ * @property {{ strategy: string, maxDistinctFishPerRun: number, skipUnavailable: boolean, allowDuplicates: boolean }} fishSelection
+ * @property {FishingStateData} fishingState
+ */
+
+/**
+ * @typedef {Object} BaitConfig
+ * @property {boolean} enabled
+ * @property {number} bonusDieSides
+ */
+
+/**
+ * @typedef {Object} FishingStateData
+ * @property {string} lastResetDateKey
+ * @property {number} caughtCounter - Successes since last DC change
+ * @property {number} notCaughtCounter - Failures since last DC change
+ * @property {import('firebase/firestore').Timestamp} resetAt
+ * @property {import('firebase/firestore').Timestamp} lastOutcomeAt
+ */
+
+/**
+ * Collection: `fishes/{fishId}`
+ * @typedef {Object} FishDoc
+ * @property {string} id
+ * @property {string} fishName
+ * @property {string} fishDescription
+ * @property {number} fishCodeNumber
+ * @property {number} fishValueSilver
+ * @property {number} fishAdditionalRollsRequiredForSuccessfulCatch
+ * @property {number} fishAmountDaily - Respawn amount per day
+ * @property {number} fishAmountAvailableNow - Current available stock
+ */
+
+/**
+ * Collection: `fishing-logs/{logId}`
+ * @typedef {Object} FishingLogDoc
+ * @property {number|string} telegramUserId
+ * @property {string} command
+ * @property {unknown[]} rawEnteredParams
+ * @property {Record<string, unknown>} normalizedParams
+ * @property {number[]} d20RawRolls
+ * @property {number[]} modifiers
+ * @property {number[]} finalRollValues
+ * @property {Record<string, unknown>} guidanceData
+ * @property {string} baitUsed
+ * @property {number} baitBonusRoll
+ * @property {number} finalComputedSum
+ * @property {unknown[]} dcChecksPerformed
+ * @property {'success'|'failure'} successFailureResult
+ * @property {Pick<FishDoc, 'id'|'fishName'|'fishDescription'|'fishCodeNumber'|'fishValueSilver'|'fishAdditionalRollsRequiredForSuccessfulCatch'>[]} fishSelected
+ * @property {number} fishQuantityCaught
+ * @property {Array<{ fishId: string, before: number, requested: number, awarded: number, after: number }>} fishAvailabilityChanges
+ * @property {unknown[]} extraCheckResults
+ * @property {import('firebase/firestore').Timestamp|string} timestamp
+ */
+
+/**
+ * Collection: `fishing-sessions/{telegramUserId}`
+ * @typedef {Object} FishingSessionDoc
+ * @property {number|string} telegramUserId
+ * @property {string} step - e.g. 'idle' | 'modifier_1' | 'modifier_2' | 'bait_choice'
+ * @property {Record<string, unknown>} payload
+ * @property {import('firebase/firestore').Timestamp|string} updatedAt
+ * @property {boolean} [staleSessionCleared]
+ */
+
+/**
+ * Collection: `telegram-processed-updates/{updateId}`
+ * @typedef {Object} TelegramProcessedUpdateDoc
+ * @property {number|string} updateId
+ * @property {import('firebase/firestore').Timestamp|string} processedAt
+ */
+
+export {}

--- a/src/types/firestore.js
+++ b/src/types/firestore.js
@@ -75,7 +75,7 @@
  */
 
 /**
- * Collection: `treasuryTransactions/{txId}`
+ * Collection: `treasury-transactions/{txId}`
  * @typedef {Object} TreasuryTransactionDoc
  * @property {string} id
  * @property {number} amount - Positive for deposits, negative for withdrawals
@@ -144,7 +144,7 @@
  */
 
 /**
- * Collection: `religionsAbilities/{abilityId}`
+ * Collection: `religion-abilities/{abilityId}`
  * @typedef {Object} ReligionAbilityDoc
  * @property {string} id
  * @property {string} name
@@ -178,9 +178,9 @@
  */
 
 /**
- * Collection: `religionActions/{actionId}`
+ * Collection: `religion-actions/{actionId}`
  * @typedef {Object} ReligionActionDoc
- * @property {import('firebase/firestore').DocumentReference} actionType - Ref to religionActionTypes
+ * @property {import('firebase/firestore').DocumentReference} actionType - Ref to religion-action-types
  * @property {string} cycleId
  * @property {string} notes
  * @property {import('firebase/firestore').Timestamp} createdAt
@@ -191,7 +191,7 @@
 // ─── DONATIONS ───────────────────────────────────────────────────────────────
 
 /**
- * Collection: `donationGoals/{goalId}`
+ * Collection: `donation-goals/{goalId}`
  * @typedef {Object} DonationGoalDoc
  * @property {string} id
  * @property {string} title
@@ -277,7 +277,7 @@
  */
 
 /**
- * Subcollection: `heroes/{heroId}/craftingLogs/{logId}`
+ * Subcollection: `heroes/{heroId}/crafting-logs/{logId}`
  * @typedef {Object} CraftingLogDoc
  * @property {string} id
  * @property {string} itemSlug
@@ -299,7 +299,7 @@
  */
 
 /**
- * Collection: `craftItems/{itemSlug}`
+ * Collection: `craft-items/{itemSlug}`
  * @typedef {Object} CraftItemDoc
  * @property {string} id
  * @property {string} name
@@ -317,7 +317,7 @@
 // ─── MAGE GUILD ──────────────────────────────────────────────────────────────
 
 /**
- * Collection: `spellRequests/{requestId}`
+ * Collection: `spell-requests/{requestId}`
  * @typedef {Object} SpellRequestDoc
  * @property {string} id
  * @property {import('firebase/firestore').DocumentReference} cycle - Ref to cycles/{cycleId}

--- a/src/views/ReligionPage.vue
+++ b/src/views/ReligionPage.vue
@@ -895,8 +895,8 @@ async function saveFollowersDistribution() {
 
     await batch.commit()
 
-    await addDoc(collection(db, 'religionActions'), {
-      actionType: doc(db, 'religionActionTypes', 'religionsDistributionChange'),
+    await addDoc(collection(db, 'religion-actions'), {
+      actionType: doc(db, 'religion-action-types', 'religionsDistributionChange'),
       changes,
       totalPopulation: totalPopulation.value,
       remaining: followersRemaining.value,
@@ -1367,8 +1367,8 @@ async function confirmReligionChange() {
         previousReligion: activeClergy.value.religionName,
         newReligion: newReligion.name,
       }),
-      addDoc(collection(db, 'religionActions'), {
-        actionType: doc(db, 'religionActionTypes', 'changeReligion'),
+      addDoc(collection(db, 'religion-actions'), {
+        actionType: doc(db, 'religion-action-types', 'changeReligion'),
         hero: heroRef || null,
         clergy: clergyRef,
         fromReligion: currentReligionRef,
@@ -1399,8 +1399,8 @@ async function createFaithAwardAction(delta) {
     ? doc(db, activeClergy.value.religion.path)
     : activeClergy.value.religion || null
 
-  await addDoc(collection(db, 'religionActions'), {
-    actionType: doc(db, 'religionActionTypes', 'awardAdventure'),
+  await addDoc(collection(db, 'religion-actions'), {
+    actionType: doc(db, 'religion-action-types', 'awardAdventure'),
     hero: heroRef,
     clergy: clergyRef,
     religion: religionRef,
@@ -1626,8 +1626,8 @@ async function applyClergyDefense() {
         user: userStore.nickname || 'Адміністратор',
         createdAt: serverTimestamp(),
       }),
-      addDoc(collection(db, 'religionActions'), {
-        actionType: doc(db, 'religionActionTypes', 'shield'),
+      addDoc(collection(db, 'religion-actions'), {
+        actionType: doc(db, 'religion-action-types', 'shield'),
         hero: heroRef,
         heroId: heroRef.id,
         clergy: clergyRef,
@@ -1798,8 +1798,8 @@ async function applySpreadReligion() {
         user: userStore.nickname || 'Адміністратор',
         createdAt: serverTimestamp(),
       }),
-      addDoc(collection(db, 'religionActions'), {
-        actionType: doc(db, 'religionActionTypes', 'influence'),
+      addDoc(collection(db, 'religion-actions'), {
+        actionType: doc(db, 'religion-action-types', 'influence'),
         hero: heroRef || null,
         heroId: heroRef?.id,
         clergy: clergyRef,
@@ -1953,8 +1953,8 @@ async function applyActiveFaithFarm() {
         user: userStore.nickname || 'Адміністратор',
         createdAt: serverTimestamp(),
       }),
-      addDoc(collection(db, 'religionActions'), {
-        actionType: doc(db, 'religionActionTypes', 'generate'),
+      addDoc(collection(db, 'religion-actions'), {
+        actionType: doc(db, 'religion-action-types', 'generate'),
         hero: heroRef,
         clergy: clergyRef,
         religion: religionRef,

--- a/tests/helpers/mockFirestore.js
+++ b/tests/helpers/mockFirestore.js
@@ -1,0 +1,285 @@
+/**
+ * In-memory Firestore mock that mirrors the firebase/firestore function API.
+ *
+ * Usage:
+ *   const mock = createMockFirestore({ 'collection/docId': { field: value } })
+ *   // Pass mock.firebase and mock.db to the function under test
+ *   await someService(options, { db: mock.db, ...mock.firebase })
+ *   // Inspect results
+ *   mock.get('collection/docId')           // single doc data or undefined
+ *   mock.list('collection')                // { id: data } map of all docs in collection
+ *   mock.listIds('collection')             // array of doc ids
+ */
+export function createMockFirestore(seed = {}) {
+  const store = new Map(Object.entries(seed))
+
+  const TIMESTAMP_SENTINEL = Symbol('serverTimestamp')
+
+  function autoId() {
+    return Math.random().toString(36).slice(2, 10) + Math.random().toString(36).slice(2, 10)
+  }
+
+  function resolveTimestamps(data) {
+    if (!data || typeof data !== 'object') return data
+    const out = {}
+    for (const [k, v] of Object.entries(data)) {
+      out[k] = v === TIMESTAMP_SENTINEL ? '__serverTimestamp__' : v
+    }
+    return out
+  }
+
+  function pathOf(ref) {
+    return ref.__path
+  }
+
+  function makeDocRef(path) {
+    return { __path: path, __type: 'doc', id: path.split('/').at(-1) }
+  }
+
+  function makeColRef(path) {
+    return { __path: path, __type: 'collection' }
+  }
+
+  // Mirrors: collection(db, 'col') or collection(docRef, 'col') or collection(db, 'col', 'id', 'subcol')
+  function collection(dbOrRef, ...segments) {
+    if (dbOrRef?.__type === 'doc') {
+      return makeColRef(`${dbOrRef.__path}/${segments.join('/')}`)
+    }
+    return makeColRef(segments.join('/'))
+  }
+
+  // Mirrors: doc(db, 'col', 'id'), doc(db, 'col/id'), doc(colRef), doc(colRef, 'id')
+  function doc(dbOrRef, ...segments) {
+    if (dbOrRef?.__type === 'collection') {
+      const id = segments[0] || autoId()
+      return makeDocRef(`${dbOrRef.__path}/${id}`)
+    }
+    // doc(db, ...segments) — join all segments
+    const path = segments.join('/')
+    return makeDocRef(path)
+  }
+
+  // Mirrors: getDoc(docRef)
+  async function getDoc(ref) {
+    const data = store.get(pathOf(ref))
+    const exists = data !== undefined
+    return {
+      exists: () => exists,
+      data: () => (exists ? { ...data } : undefined),
+      ref,
+      id: ref.id,
+    }
+  }
+
+  // Mirrors: getDocs(query)
+  async function getDocs(queryObj) {
+    const colPath = queryObj.__colPath || queryObj.__path
+    const constraints = queryObj.__constraints || []
+
+    const prefix = colPath + '/'
+    let docs = []
+    for (const [path, data] of store.entries()) {
+      if (path.startsWith(prefix) && !path.slice(prefix.length).includes('/')) {
+        docs.push({ id: path.slice(prefix.length), __path: path, data: () => ({ ...data }), ref: makeDocRef(path) })
+      }
+    }
+
+    // Apply where constraints
+    for (const c of constraints) {
+      if (c.__type !== 'where') continue
+      docs = docs.filter((d) => {
+        const val = c.field === '__documentId__' ? d.id : d.data()[c.field]
+        if (c.op === '==') {
+          if (val?.__path !== undefined && c.value?.__path !== undefined) return val.__path === c.value.__path
+          return val === c.value
+        }
+        if (c.op === '!=') return val !== c.value
+        if (c.op === 'in') return Array.isArray(c.value) && c.value.includes(val)
+        if (c.op === 'not-in') return Array.isArray(c.value) && !c.value.includes(val)
+        if (c.op === '>') return val > c.value
+        if (c.op === '>=') return val >= c.value
+        if (c.op === '<') return val < c.value
+        if (c.op === '<=') return val <= c.value
+        return true
+      })
+    }
+
+    // Apply orderBy
+    for (const c of constraints) {
+      if (c.__type !== 'orderBy') continue
+      docs.sort((a, b) => {
+        const va = a.data()[c.field]
+        const vb = b.data()[c.field]
+        const dir = c.direction === 'desc' ? -1 : 1
+        if (va == null && vb == null) return 0
+        if (va == null) return dir
+        if (vb == null) return -dir
+        return (va < vb ? -1 : va > vb ? 1 : 0) * dir
+      })
+    }
+
+    // Apply startAfter
+    for (const c of constraints) {
+      if (c.__type !== 'startAfter') continue
+      const idx = docs.findIndex((d) => d.__path === c.cursor?.__path)
+      if (idx !== -1) docs = docs.slice(idx + 1)
+    }
+
+    // Apply limit
+    for (const c of constraints) {
+      if (c.__type !== 'limit') continue
+      docs = docs.slice(0, c.n)
+    }
+
+    return { docs, empty: docs.length === 0, size: docs.length }
+  }
+
+  // Mirrors: addDoc(colRef, data)
+  async function addDoc(colRef, data) {
+    const id = autoId()
+    const path = `${pathOf(colRef)}/${id}`
+    store.set(path, resolveTimestamps(data))
+    return makeDocRef(path)
+  }
+
+  // Mirrors: setDoc(ref, data) / setDoc(ref, data, { merge: true })
+  async function setDoc(ref, data, options = {}) {
+    const path = pathOf(ref)
+    if (options.merge && store.has(path)) {
+      store.set(path, { ...store.get(path), ...resolveTimestamps(data) })
+    } else {
+      store.set(path, resolveTimestamps(data))
+    }
+  }
+
+  // Mirrors: updateDoc(ref, data)
+  async function updateDoc(ref, data) {
+    const path = pathOf(ref)
+    store.set(path, { ...(store.get(path) || {}), ...resolveTimestamps(data) })
+  }
+
+  // Mirrors: deleteDoc(ref)
+  async function deleteDoc(ref) {
+    store.delete(pathOf(ref))
+  }
+
+  // Mirrors: runTransaction(db, fn)
+  async function runTransaction(_db, fn) {
+    const ops = []
+    const t = {
+      async get(ref) { return getDoc(ref) },
+      set(ref, data, options = {}) { ops.push({ type: 'set', ref, data, options }) },
+      update(ref, data) { ops.push({ type: 'update', ref, data }) },
+      delete(ref) { ops.push({ type: 'delete', ref }) },
+    }
+    const result = await fn(t)
+    for (const op of ops) {
+      if (op.type === 'set') await setDoc(op.ref, op.data, op.options)
+      if (op.type === 'update') await updateDoc(op.ref, op.data)
+      if (op.type === 'delete') await deleteDoc(op.ref)
+    }
+    return result
+  }
+
+  // Mirrors: writeBatch(db)
+  function writeBatch() {
+    const ops = []
+    return {
+      set(ref, data, options = {}) { ops.push({ type: 'set', ref, data, options }) },
+      update(ref, data) { ops.push({ type: 'update', ref, data }) },
+      delete(ref) { ops.push({ type: 'delete', ref }) },
+      async commit() {
+        for (const op of ops) {
+          if (op.type === 'set') await setDoc(op.ref, op.data, op.options)
+          if (op.type === 'update') await updateDoc(op.ref, op.data)
+          if (op.type === 'delete') await deleteDoc(op.ref)
+        }
+      },
+    }
+  }
+
+  // Mirrors: query(colRef, ...constraints)
+  function query(colRef, ...constraints) {
+    return { __colPath: pathOf(colRef), __constraints: constraints }
+  }
+
+  // Mirrors: where(field, op, value)
+  function where(field, op, value) {
+    return { __type: 'where', field: pathOf(field) ?? field, op, value }
+  }
+
+  // Mirrors: orderBy(field, direction?)
+  function orderBy(field, direction = 'asc') {
+    return { __type: 'orderBy', field, direction }
+  }
+
+  // Mirrors: limit(n)
+  function limit(n) {
+    return { __type: 'limit', n }
+  }
+
+  // Mirrors: startAfter(docSnap)
+  function startAfter(cursor) {
+    return { __type: 'startAfter', cursor }
+  }
+
+  // Mirrors: documentId()
+  function documentId() {
+    return { __path: '__documentId__' }
+  }
+
+  // Mirrors: serverTimestamp()
+  function serverTimestamp() {
+    return TIMESTAMP_SENTINEL
+  }
+
+  const db = { __isMockDb: true }
+
+  const firebase = {
+    collection,
+    doc,
+    getDoc,
+    getDocs,
+    addDoc,
+    setDoc,
+    updateDoc,
+    deleteDoc,
+    runTransaction,
+    writeBatch,
+    query,
+    where,
+    orderBy,
+    limit,
+    startAfter,
+    documentId,
+    serverTimestamp,
+  }
+
+  return {
+    db,
+    firebase,
+    // Inspection helpers for assertions
+    get: (path) => store.get(path),
+    list: (colPath) => {
+      const prefix = colPath + '/'
+      const result = {}
+      for (const [path, data] of store.entries()) {
+        if (path.startsWith(prefix) && !path.slice(prefix.length).includes('/')) {
+          result[path.slice(prefix.length)] = data
+        }
+      }
+      return result
+    },
+    listIds: (colPath) => Object.keys(
+      (() => {
+        const prefix = colPath + '/'
+        const ids = []
+        for (const path of store.keys()) {
+          if (path.startsWith(prefix) && !path.slice(prefix.length).includes('/')) ids.push(path.slice(prefix.length))
+        }
+        return ids
+      })()
+    ),
+    store,
+  }
+}

--- a/tests/services/craftingService.test.js
+++ b/tests/services/craftingService.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { registerCraftAction } from '../../src/services/craftingService.ts';
+import { createMockFirestore } from '../helpers/mockFirestore.js';
+
+const SWORD_ITEM = {
+  slug: 'longsword',
+  name: 'Longsword',
+  category: 'Weapons',
+  subcategory: 'Swords',
+  categoryKey: 'weapons',
+  subcategoryKey: 'weapons_swords',
+  componentPrice: 15,
+  weight: 3,
+  craftDays: 2,
+  dc: 12,
+  isActive: true,
+};
+
+const DAGGER_ITEM = {
+  slug: 'dagger',
+  name: 'Dagger',
+  category: 'Weapons',
+  subcategory: 'Swords',
+  categoryKey: 'weapons',
+  subcategoryKey: 'weapons_swords',
+  componentPrice: 5,
+  weight: 0.5,
+  craftDays: 1,
+  dc: 8,
+  isActive: true,
+};
+
+function makeDeps(seed = {}) {
+  const mock = createMockFirestore(seed);
+  return {
+    mock,
+    deps: {
+      db: mock.db,
+      doc: mock.firebase.doc,
+      collection: mock.firebase.collection,
+      getDocs: mock.firebase.getDocs,
+      query: mock.firebase.query,
+      runTransaction: mock.firebase.runTransaction,
+      serverTimestamp: mock.firebase.serverTimestamp,
+    },
+  };
+}
+
+test('registerCraftAction updates hero crafting progress and writes a log entry', async () => {
+  const { mock, deps } = makeDeps({
+    'heroes/hero1': { name: 'Gandalf', crafting: null },
+  });
+
+  const result = await registerCraftAction(
+    { heroId: 'hero1', itemSlug: 'longsword', amountCrafted: 3, craftItems: [SWORD_ITEM], createdBy: 'player1' },
+    deps,
+  );
+
+  assert.ok(result.crafting, 'should return updated crafting state');
+  assert.equal(result.heroId, 'hero1');
+  assert.equal(result.amountCrafted, 3);
+
+  const heroData = mock.get('heroes/hero1');
+  assert.ok(heroData.crafting, 'hero crafting field should be updated');
+  assert.ok(heroData.crafting.itemProgress?.longsword, 'item progress should be recorded');
+
+  const logs = Object.values(mock.list('heroes/hero1/craftingLogs'));
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].itemSlug, 'longsword');
+  assert.equal(logs[0].itemName, 'Longsword');
+  assert.equal(logs[0].amountCrafted, 3);
+  assert.equal(logs[0].componentPriceAtTime, 15);
+  assert.equal(logs[0].totalComponentPriceAtTime, 45);
+  assert.equal(logs[0].createdBy, 'player1');
+});
+
+test('registerCraftAction accumulates progress across multiple craft actions', async () => {
+  const { mock, deps } = makeDeps({
+    'heroes/hero1': { name: 'Gandalf', crafting: null },
+  });
+
+  await registerCraftAction(
+    { heroId: 'hero1', itemSlug: 'longsword', amountCrafted: 2, craftItems: [SWORD_ITEM] },
+    deps,
+  );
+  await registerCraftAction(
+    { heroId: 'hero1', itemSlug: 'longsword', amountCrafted: 3, craftItems: [SWORD_ITEM] },
+    deps,
+  );
+
+  const logs = Object.values(mock.list('heroes/hero1/craftingLogs'));
+  assert.equal(logs.length, 2);
+
+  const heroData = mock.get('heroes/hero1');
+  const totalCraftActions = heroData.crafting?.summary?.totalCraftActions;
+  assert.equal(totalCraftActions, 2);
+});
+
+test('registerCraftAction logs before/after progress values', async () => {
+  const { mock, deps } = makeDeps({
+    'heroes/hero1': { name: 'Gandalf', crafting: null },
+  });
+
+  await registerCraftAction(
+    { heroId: 'hero1', itemSlug: 'longsword', amountCrafted: 1, craftItems: [SWORD_ITEM] },
+    deps,
+  );
+
+  const logs = Object.values(mock.list('heroes/hero1/craftingLogs'));
+  const log = logs[0];
+  assert.equal(log.categoryBefore, 0);
+  assert.ok(log.categoryAfter >= 0, 'categoryAfter should be set');
+  assert.equal(typeof log.categoryCappedReached, 'boolean');
+});
+
+test('registerCraftAction throws when hero does not exist', async () => {
+  const { deps } = makeDeps({});
+
+  await assert.rejects(
+    () => registerCraftAction(
+      { heroId: 'nonexistent', itemSlug: 'longsword', amountCrafted: 1, craftItems: [SWORD_ITEM] },
+      deps,
+    ),
+    /Hero not found/,
+  );
+});
+
+test('registerCraftAction throws when item slug is not in craftItems', async () => {
+  const { deps } = makeDeps({ 'heroes/hero1': { name: 'Gandalf', crafting: null } });
+
+  await assert.rejects(
+    () => registerCraftAction(
+      { heroId: 'hero1', itemSlug: 'nonexistent-item', amountCrafted: 1, craftItems: [SWORD_ITEM] },
+      deps,
+    ),
+    /Craft item not found/,
+  );
+});
+
+test('registerCraftAction tracks different items independently', async () => {
+  const { mock, deps } = makeDeps({
+    'heroes/hero1': { name: 'Gandalf', crafting: null },
+  });
+
+  await registerCraftAction(
+    { heroId: 'hero1', itemSlug: 'longsword', amountCrafted: 1, craftItems: [SWORD_ITEM, DAGGER_ITEM] },
+    deps,
+  );
+  await registerCraftAction(
+    { heroId: 'hero1', itemSlug: 'dagger', amountCrafted: 2, craftItems: [SWORD_ITEM, DAGGER_ITEM] },
+    deps,
+  );
+
+  const heroData = mock.get('heroes/hero1');
+  assert.ok(heroData.crafting.itemProgress.longsword, 'longsword progress should exist');
+  assert.ok(heroData.crafting.itemProgress.dagger, 'dagger progress should exist');
+});

--- a/tests/services/craftingService.test.js
+++ b/tests/services/craftingService.test.js
@@ -65,7 +65,7 @@ test('registerCraftAction updates hero crafting progress and writes a log entry'
   assert.ok(heroData.crafting, 'hero crafting field should be updated');
   assert.ok(heroData.crafting.itemProgress?.longsword, 'item progress should be recorded');
 
-  const logs = Object.values(mock.list('heroes/hero1/craftingLogs'));
+  const logs = Object.values(mock.list('heroes/hero1/crafting-logs'));
   assert.equal(logs.length, 1);
   assert.equal(logs[0].itemSlug, 'longsword');
   assert.equal(logs[0].itemName, 'Longsword');
@@ -89,7 +89,7 @@ test('registerCraftAction accumulates progress across multiple craft actions', a
     deps,
   );
 
-  const logs = Object.values(mock.list('heroes/hero1/craftingLogs'));
+  const logs = Object.values(mock.list('heroes/hero1/crafting-logs'));
   assert.equal(logs.length, 2);
 
   const heroData = mock.get('heroes/hero1');
@@ -107,7 +107,7 @@ test('registerCraftAction logs before/after progress values', async () => {
     deps,
   );
 
-  const logs = Object.values(mock.list('heroes/hero1/craftingLogs'));
+  const logs = Object.values(mock.list('heroes/hero1/crafting-logs'));
   const log = logs[0];
   assert.equal(log.categoryBefore, 0);
   assert.ok(log.categoryAfter >= 0, 'categoryAfter should be set');

--- a/tests/services/cycleService.test.js
+++ b/tests/services/cycleService.test.js
@@ -1,0 +1,275 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resetReligionsSvTemp,
+  loadManufacturesByIds,
+  distributeManufactureIncome,
+  distributeBuildingFaithIncome,
+  createNewCycleWithEffects,
+} from '../../src/services/cycleService.js';
+import { createMockFirestore } from '../helpers/mockFirestore.js';
+
+// ─── resetReligionsSvTemp ────────────────────────────────────────────────────
+
+test('resetReligionsSvTemp sets svTemp to 0 on all religion docs', async () => {
+  const mock = createMockFirestore({
+    'religions/rel1': { name: 'Tyr', svTemp: 5 },
+    'religions/rel2': { name: 'Helm', svTemp: 12 },
+  });
+
+  await resetReligionsSvTemp({ ...mock.firebase, db: mock.db });
+
+  assert.equal(mock.get('religions/rel1').svTemp, 0);
+  assert.equal(mock.get('religions/rel2').svTemp, 0);
+});
+
+test('resetReligionsSvTemp does nothing when collection is empty', async () => {
+  const mock = createMockFirestore({});
+  await assert.doesNotReject(() => resetReligionsSvTemp({ ...mock.firebase, db: mock.db }));
+});
+
+// ─── loadManufacturesByIds ───────────────────────────────────────────────────
+
+test('loadManufacturesByIds returns normalised manufacture entries', async () => {
+  const mock = createMockFirestore({
+    'manufactures/m1': { name: '  Mine  ', income: 100, incomeDestination: 'treasury' },
+    'manufactures/m2': { name: 'Farm', income: 50, incomeDestination: 'guild:guild-a' },
+  });
+
+  const result = await loadManufacturesByIds(['m1', 'm2'], { ...mock.firebase, db: mock.db });
+
+  assert.equal(result.length, 2);
+  assert.equal(result[0].name, 'Mine');
+  assert.equal(result[0].income, 100);
+  assert.equal(result[1].incomeDestination, 'guild:guild-a');
+});
+
+test('loadManufacturesByIds returns empty array for empty ids', async () => {
+  const mock = createMockFirestore({});
+  const result = await loadManufacturesByIds([], { ...mock.firebase, db: mock.db });
+  assert.deepEqual(result, []);
+});
+
+test('loadManufacturesByIds preserves requested order', async () => {
+  const mock = createMockFirestore({
+    'manufactures/a': { name: 'A', income: 10, incomeDestination: 'treasury' },
+    'manufactures/b': { name: 'B', income: 20, incomeDestination: 'treasury' },
+  });
+
+  const result = await loadManufacturesByIds(['b', 'a'], { ...mock.firebase, db: mock.db });
+
+  assert.equal(result[0].id, 'b');
+  assert.equal(result[1].id, 'a');
+});
+
+// ─── distributeManufactureIncome ─────────────────────────────────────────────
+
+test('distributeManufactureIncome adds treasury balance from population income', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 1000 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock',
+    [{ id: 'p1', name: 'Merchants', count: 10, incomePerPerson: 5, description: '' }],
+    { ...mock.firebase, db: mock.db },
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 1050);
+
+  const txs = Object.values(mock.list('treasuryTransactions'));
+  assert.equal(txs.length, 1);
+  assert.equal(txs[0].amount, 50);
+  assert.equal(txs[0].type, 'deposit');
+  assert.equal(txs[0].userId, 'system');
+  assert.equal(txs[0].cycleId, 'cycle-1');
+});
+
+test('distributeManufactureIncome routes guild-destined manufacture income to guild', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: ['m1'] },
+    'manufactures/m1': { name: 'Quarry', income: 200, incomeDestination: 'guild:guild-a' },
+    'guilds/guild-a': { treasure: 300 },
+    'treasury/meta': { balance: 500 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock', [],
+    { ...mock.firebase, db: mock.db },
+  );
+
+  assert.equal(mock.get('guilds/guild-a').treasure, 500);
+  assert.equal(mock.get('treasury/meta').balance, 500); // treasury unchanged
+
+  const guildLogs = Object.values(mock.list('guilds/guild-a/logs'));
+  assert.equal(guildLogs.length, 1);
+  assert.equal(guildLogs[0].amount, 200);
+});
+
+test('distributeManufactureIncome does nothing when island has no income sources', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock', [],
+    { ...mock.firebase, db: mock.db },
+  );
+
+  assert.equal(Object.keys(mock.list('treasuryTransactions')).length, 0);
+});
+
+test('distributeManufactureIncome does nothing when island doc is missing', async () => {
+  const mock = createMockFirestore({ 'treasury/meta': { balance: 100 } });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'nonexistent_island', [],
+    { ...mock.firebase, db: mock.db },
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 100);
+});
+
+// ─── distributeBuildingFaithIncome ───────────────────────────────────────────
+
+test('distributeBuildingFaithIncome distributes faith to eligible clergy', async () => {
+  const mock = createMockFirestore({
+    'religions/rel1': { name: 'Tyr', buildingLevel: 'chapel' }, // chapel gives 5 passive faith
+    'clergy/c1': { faith: 0, faithMax: 0, religion: { __path: 'religions/rel1', __type: 'doc' } },
+  });
+
+  await distributeBuildingFaithIncome('cycle-1', {
+    ...mock.firebase,
+    db: mock.db,
+    rng: () => 0,
+  });
+
+  const clergy = mock.get('clergy/c1');
+  assert.ok(clergy.faith > 0, 'faith should increase');
+
+  const logs = Object.values(mock.list('clergy/c1/logs'));
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].cycleId, 'cycle-1');
+  assert.equal(logs[0].user, 'Система');
+});
+
+test('distributeBuildingFaithIncome skips religions with no building', async () => {
+  const mock = createMockFirestore({
+    'religions/rel1': { name: 'Tyr', buildingLevel: 'none' },
+    'clergy/c1': { faith: 0, faithMax: 0, religion: { __path: 'religions/rel1', __type: 'doc' } },
+  });
+
+  await distributeBuildingFaithIncome('cycle-1', { ...mock.firebase, db: mock.db, rng: () => 0 });
+
+  assert.equal(mock.get('clergy/c1').faith, 0);
+});
+
+test('distributeBuildingFaithIncome skips clergy with passiveOVInactive hero', async () => {
+  const mock = createMockFirestore({
+    'religions/rel1': { name: 'Tyr', buildingLevel: 'chapel' },
+    'heroes/h1': { passiveOVInactive: true },
+    'clergy/c1': {
+      faith: 0, faithMax: 0,
+      religion: { __path: 'religions/rel1', __type: 'doc' },
+      hero: { __path: 'heroes/h1', __type: 'doc' },
+    },
+  });
+
+  await distributeBuildingFaithIncome('cycle-1', { ...mock.firebase, db: mock.db, rng: () => 0 });
+
+  assert.equal(mock.get('clergy/c1').faith, 0);
+});
+
+// ─── createNewCycleWithEffects ───────────────────────────────────────────────
+
+test('createNewCycleWithEffects creates cycle doc with startedAt', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  const result = await createNewCycleWithEffects(
+    { startedDate: '1 Hammer 1490', islandId: 'island_rock' },
+    {
+      ...mock.firebase,
+      db: mock.db,
+      settlePreviousSpellRequestsFn: async () => {},
+      generateSpellRequestsForCycleFn: async () => {},
+    },
+  );
+
+  assert.ok(result.id, 'should return cycle id');
+  assert.ok(result.startedAt, 'should return startedAt');
+
+  const cycles = Object.values(mock.list('cycles'));
+  assert.equal(cycles.length, 1);
+  assert.ok(cycles[0].startedAt);
+});
+
+test('createNewCycleWithEffects closes open previous cycle', async () => {
+  const mock = createMockFirestore({
+    'cycles/prev': { startedAt: '1 Uktar 1489', createdAt: 'old' },
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  await createNewCycleWithEffects(
+    { startedDate: '1 Hammer 1490', islandId: 'island_rock' },
+    {
+      ...mock.firebase,
+      db: mock.db,
+      getDocs: async (q) => {
+        // Return prev cycle for the "last cycle" query
+        if (q.__colPath === 'cycles') {
+          return {
+            docs: [{ id: 'prev', data: () => mock.get('cycles/prev'), ref: { __path: 'cycles/prev', __type: 'doc', id: 'prev' } }],
+            empty: false,
+          };
+        }
+        return mock.firebase.getDocs(q);
+      },
+      settlePreviousSpellRequestsFn: async () => {},
+      generateSpellRequestsForCycleFn: async () => {},
+    },
+  );
+
+  assert.ok(mock.get('cycles/prev').finishedAt, 'previous cycle should be closed');
+});
+
+test('createNewCycleWithEffects throws on invalid date', async () => {
+  const mock = createMockFirestore({});
+
+  await assert.rejects(
+    () => createNewCycleWithEffects({ startedDate: 'not-a-date' }, {
+      ...mock.firebase,
+      db: mock.db,
+      settlePreviousSpellRequestsFn: async () => {},
+      generateSpellRequestsForCycleFn: async () => {},
+    }),
+    /INVALID_START_DATE/,
+  );
+});
+
+test('createNewCycleWithEffects writes religionAction doc', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  await createNewCycleWithEffects(
+    { startedDate: '1 Hammer 1490', notes: 'Test cycle' },
+    {
+      ...mock.firebase,
+      db: mock.db,
+      settlePreviousSpellRequestsFn: async () => {},
+      generateSpellRequestsForCycleFn: async () => {},
+    },
+  );
+
+  const actions = Object.values(mock.list('religionActions'));
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].notes, 'Test cycle');
+  assert.equal(actions[0].convertedFollowers, 0);
+});

--- a/tests/services/cycleService.test.js
+++ b/tests/services/cycleService.test.js
@@ -78,7 +78,7 @@ test('distributeManufactureIncome adds treasury balance from population income',
 
   assert.equal(mock.get('treasury/meta').balance, 1050);
 
-  const txs = Object.values(mock.list('treasuryTransactions'));
+  const txs = Object.values(mock.list('treasury-transactions'));
   assert.equal(txs.length, 1);
   assert.equal(txs[0].amount, 50);
   assert.equal(txs[0].type, 'deposit');
@@ -118,7 +118,7 @@ test('distributeManufactureIncome does nothing when island has no income sources
     { ...mock.firebase, db: mock.db },
   );
 
-  assert.equal(Object.keys(mock.list('treasuryTransactions')).length, 0);
+  assert.equal(Object.keys(mock.list('treasury-transactions')).length, 0);
 });
 
 test('distributeManufactureIncome does nothing when island doc is missing', async () => {
@@ -268,7 +268,7 @@ test('createNewCycleWithEffects writes religionAction doc', async () => {
     },
   );
 
-  const actions = Object.values(mock.list('religionActions'));
+  const actions = Object.values(mock.list('religion-actions'));
   assert.equal(actions.length, 1);
   assert.equal(actions[0].notes, 'Test cycle');
   assert.equal(actions[0].convertedFollowers, 0);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,4 @@
+// Preloaded via `node --import` before any test module loads.
+// Sets browser globals that pinia's devtools-kit calls at module init time.
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {}, clear: () => {} }
+globalThis.sessionStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {}, clear: () => {} }

--- a/tests/store/guildStore.test.js
+++ b/tests/store/guildStore.test.js
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { applyGuildTransaction } from '../../src/store/guildStore.js';
+import { createMockFirestore } from '../helpers/mockFirestore.js';
+
+function makeDeps(seed = {}) {
+  const mock = createMockFirestore(seed);
+  return {
+    mock,
+    deps: {
+      db: mock.db,
+      runTransactionFn: mock.firebase.runTransaction,
+      docFn: mock.firebase.doc,
+      collectionFn: mock.firebase.collection,
+      serverTimestampFn: mock.firebase.serverTimestamp,
+    },
+  };
+}
+
+test('deposit increases guild treasure and writes log entry', async () => {
+  const { mock, deps } = makeDeps({ 'guilds/guild-a': { treasure: 500 } });
+
+  await applyGuildTransaction(
+    { guildId: 'guild-a', amount: 200, comment: 'Raid loot', actor: { nickname: 'Captain' }, type: 'deposit' },
+    deps,
+  );
+
+  assert.equal(mock.get('guilds/guild-a').treasure, 700);
+
+  const logs = Object.values(mock.list('guilds/guild-a/logs'));
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].amount, 200);
+  assert.equal(logs[0].type, 'deposit');
+  assert.equal(logs[0].treasureAfter, 700);
+  assert.equal(logs[0].userNickname, 'Captain');
+});
+
+test('withdrawal decreases guild treasure and writes log entry', async () => {
+  const { mock, deps } = makeDeps({ 'guilds/guild-b': { treasure: 1000 } });
+
+  await applyGuildTransaction(
+    { guildId: 'guild-b', amount: -300, comment: 'Equipment', actor: { nickname: 'Treasurer' }, type: 'withdraw' },
+    deps,
+  );
+
+  assert.equal(mock.get('guilds/guild-b').treasure, 700);
+
+  const logs = Object.values(mock.list('guilds/guild-b/logs'));
+  assert.equal(logs[0].amount, -300);
+  assert.equal(logs[0].treasureAfter, 700);
+});
+
+test('throws when withdrawal would make guild treasure negative', async () => {
+  const { deps } = makeDeps({ 'guilds/guild-c': { treasure: 100 } });
+
+  await assert.rejects(
+    () => applyGuildTransaction(
+      { guildId: 'guild-c', amount: -200, comment: '', actor: null, type: 'withdraw' },
+      deps,
+    ),
+    /Not enough guild treasure/,
+  );
+});
+
+test('throws when guild document does not exist', async () => {
+  const { deps } = makeDeps({});
+
+  await assert.rejects(
+    () => applyGuildTransaction(
+      { guildId: 'nonexistent', amount: 100, comment: '', actor: null, type: 'deposit' },
+      deps,
+    ),
+    /Guild not found/,
+  );
+});
+
+test('log comment is truncated to 500 characters', async () => {
+  const { mock, deps } = makeDeps({ 'guilds/guild-d': { treasure: 0 } });
+
+  await applyGuildTransaction(
+    { guildId: 'guild-d', amount: 1, comment: 'x'.repeat(600), actor: null, type: 'deposit' },
+    deps,
+  );
+
+  const logs = Object.values(mock.list('guilds/guild-d/logs'));
+  assert.equal(logs[0].comment.length, 500);
+});
+
+test('falls back to Unknown nickname when actor is missing', async () => {
+  const { mock, deps } = makeDeps({ 'guilds/guild-e': { treasure: 0 } });
+
+  await applyGuildTransaction(
+    { guildId: 'guild-e', amount: 10, comment: '', actor: null, type: 'deposit' },
+    deps,
+  );
+
+  const logs = Object.values(mock.list('guilds/guild-e/logs'));
+  assert.equal(logs[0].userNickname, 'Unknown');
+});
+
+test('multiple transactions accumulate correctly', async () => {
+  const { mock, deps } = makeDeps({ 'guilds/guild-f': { treasure: 100 } });
+
+  await applyGuildTransaction({ guildId: 'guild-f', amount: 50, comment: 'A', actor: null, type: 'deposit' }, deps);
+  await applyGuildTransaction({ guildId: 'guild-f', amount: -30, comment: 'B', actor: null, type: 'withdraw' }, deps);
+
+  assert.equal(mock.get('guilds/guild-f').treasure, 120);
+  assert.equal(Object.keys(mock.list('guilds/guild-f/logs')).length, 2);
+});

--- a/tests/store/treasuryStore.test.js
+++ b/tests/store/treasuryStore.test.js
@@ -28,7 +28,7 @@ test('deposit adds amount to balance and writes transaction record', async () =>
   const meta = mock.get('treasury/meta');
   assert.equal(meta.balance, 150);
 
-  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  const txDocs = Object.values(mock.list('treasury-transactions'));
   assert.equal(txDocs.length, 1);
   assert.equal(txDocs[0].amount, 50);
   assert.equal(txDocs[0].type, 'deposit');
@@ -49,7 +49,7 @@ test('withdraw subtracts amount and writes transaction record', async () => {
   const meta = mock.get('treasury/meta');
   assert.equal(meta.balance, 120);
 
-  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  const txDocs = Object.values(mock.list('treasury-transactions'));
   assert.equal(txDocs[0].amount, -80);
   assert.equal(txDocs[0].type, 'withdraw');
   assert.equal(txDocs[0].balanceAfter, 120);
@@ -84,7 +84,7 @@ test('truncates comment to 500 characters', async () => {
     deps,
   );
 
-  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  const txDocs = Object.values(mock.list('treasury-transactions'));
   assert.equal(txDocs[0].comment.length, 500);
 });
 
@@ -93,7 +93,7 @@ test('falls back to anon and default nickname when user is missing', async () =>
 
   await applyTreasuryTransaction({ delta: 10, type: 'deposit', comment: '', user: null }, deps);
 
-  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  const txDocs = Object.values(mock.list('treasury-transactions'));
   assert.equal(txDocs[0].userId, 'anon');
   assert.equal(txDocs[0].nickname, 'Гравець');
 });
@@ -104,7 +104,7 @@ test('each deposit writes a separate transaction document', async () => {
   await applyTreasuryTransaction({ delta: 10, type: 'deposit', comment: 'A', user: null }, deps);
   await applyTreasuryTransaction({ delta: 20, type: 'deposit', comment: 'B', user: null }, deps);
 
-  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  const txDocs = Object.values(mock.list('treasury-transactions'));
   assert.equal(txDocs.length, 2);
   assert.equal(mock.get('treasury/meta').balance, 30);
 });

--- a/tests/store/treasuryStore.test.js
+++ b/tests/store/treasuryStore.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { applyTreasuryTransaction } from '../../src/store/treasuryStore.js';
+import { createMockFirestore } from '../helpers/mockFirestore.js';
+
+function makeDeps(seed = {}) {
+  const mock = createMockFirestore(seed);
+  return {
+    mock,
+    deps: {
+      db: mock.db,
+      runTransactionFn: mock.firebase.runTransaction,
+      docFn: mock.firebase.doc,
+      collectionFn: mock.firebase.collection,
+      serverTimestampFn: mock.firebase.serverTimestamp,
+    },
+  };
+}
+
+test('deposit adds amount to balance and writes transaction record', async () => {
+  const { mock, deps } = makeDeps({ 'treasury/meta': { balance: 100 } });
+
+  await applyTreasuryTransaction(
+    { delta: 50, type: 'deposit', comment: 'Test deposit', user: { uid: 'u1', nickname: 'Alice' } },
+    deps,
+  );
+
+  const meta = mock.get('treasury/meta');
+  assert.equal(meta.balance, 150);
+
+  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  assert.equal(txDocs.length, 1);
+  assert.equal(txDocs[0].amount, 50);
+  assert.equal(txDocs[0].type, 'deposit');
+  assert.equal(txDocs[0].balanceAfter, 150);
+  assert.equal(txDocs[0].userId, 'u1');
+  assert.equal(txDocs[0].nickname, 'Alice');
+  assert.equal(txDocs[0].comment, 'Test deposit');
+});
+
+test('withdraw subtracts amount and writes transaction record', async () => {
+  const { mock, deps } = makeDeps({ 'treasury/meta': { balance: 200 } });
+
+  await applyTreasuryTransaction(
+    { delta: -80, type: 'withdraw', comment: 'Supplies', user: { uid: 'u2', nickname: 'Bob' } },
+    deps,
+  );
+
+  const meta = mock.get('treasury/meta');
+  assert.equal(meta.balance, 120);
+
+  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  assert.equal(txDocs[0].amount, -80);
+  assert.equal(txDocs[0].type, 'withdraw');
+  assert.equal(txDocs[0].balanceAfter, 120);
+});
+
+test('throws when withdrawal would make balance negative', async () => {
+  const { deps } = makeDeps({ 'treasury/meta': { balance: 30 } });
+
+  await assert.rejects(
+    () => applyTreasuryTransaction({ delta: -50, type: 'withdraw', comment: '', user: null }, deps),
+    /Недостатньо золота/,
+  );
+});
+
+test('creates meta doc when it does not exist yet', async () => {
+  const { mock, deps } = makeDeps({});
+
+  await applyTreasuryTransaction(
+    { delta: 100, type: 'deposit', comment: 'First deposit', user: null },
+    deps,
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 100);
+});
+
+test('truncates comment to 500 characters', async () => {
+  const { mock, deps } = makeDeps({ 'treasury/meta': { balance: 0 } });
+  const longComment = 'x'.repeat(600);
+
+  await applyTreasuryTransaction(
+    { delta: 1, type: 'deposit', comment: longComment, user: null },
+    deps,
+  );
+
+  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  assert.equal(txDocs[0].comment.length, 500);
+});
+
+test('falls back to anon and default nickname when user is missing', async () => {
+  const { mock, deps } = makeDeps({ 'treasury/meta': { balance: 0 } });
+
+  await applyTreasuryTransaction({ delta: 10, type: 'deposit', comment: '', user: null }, deps);
+
+  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  assert.equal(txDocs[0].userId, 'anon');
+  assert.equal(txDocs[0].nickname, 'Гравець');
+});
+
+test('each deposit writes a separate transaction document', async () => {
+  const { mock, deps } = makeDeps({ 'treasury/meta': { balance: 0 } });
+
+  await applyTreasuryTransaction({ delta: 10, type: 'deposit', comment: 'A', user: null }, deps);
+  await applyTreasuryTransaction({ delta: 20, type: 'deposit', comment: 'B', user: null }, deps);
+
+  const txDocs = Object.values(mock.list('treasuryTransactions'));
+  assert.equal(txDocs.length, 2);
+  assert.equal(mock.get('treasury/meta').balance, 30);
+});


### PR DESCRIPTION
## Summary

- **Firestore schema documented** — all 26+ collections defined as JSDoc typedefs in `src/types/firestore.js`, enforced as source of truth in `CLAUDE.md`
- **Test coverage added** — 124 tests across treasury, guild, crafting, and cycle service logic using an in-memory Firestore mock (`tests/helpers/mockFirestore.js`)
- **Collection names standardised** — all multi-word Firestore collections renamed to kebab-case (e.g. `treasuryTransactions` → `treasury-transactions`, `craftItems` → `craft-items`)
- **Migration completed** — data copied to new collection names in prod via `scripts/migrate-collection-names.js`; old collections left intact

## What changed

### New files
- `src/types/firestore.js` — JSDoc typedefs for every collection/subcollection
- `tests/helpers/mockFirestore.js` — in-memory Firestore mock mirroring the Firebase v9 API
- `tests/setup.js` — Node preload to stub `localStorage` before pinia loads
- `tests/store/treasuryStore.test.js`, `guildStore.test.js`
- `tests/services/craftingService.test.js`, `cycleService.test.js`
- `scripts/migrate-collection-names.js` — one-time migration (already run against prod)
- `scripts/backup-firestore.js` — local JSON backup utility
- `scripts/verify-migration.js` — post-migration verification

### Modified files
- `src/store/treasuryStore.js`, `guildStore.js` — extracted testable `applyTreasuryTransaction` / `applyGuildTransaction` functions with injectable deps
- `src/services/cycleService.js`, `craftingService.ts`, `mageGuildService.js` — injectable deps for testability; fixed `@/` path aliases → relative paths; fixed `faerun-date` import
- All stores and services — Firestore collection string literals updated to kebab-case
- `src/views/ReligionPage.vue` — `religionActions` / `religionActionTypes` → `religion-actions` / `religion-action-types`
- `CLAUDE.md` — added Firestore schema section with update enforcement rule

## Reviewer notes

- Migration was run against prod Firestore before this PR. Old collections still exist and can be deleted from Firebase Console after merge+deploy.
- 124/124 tests pass.
- `firebase-admin` added as devDependency (used only by scripts, not bundled).

## Test plan
- [x] `npm test` — 124 pass, 0 fail
- [x] `npm run build` — clean build
- [x] Deployed to staging channel — verified app loads correctly
- [x] Migration verified via `scripts/verify-migration.js` — all collections match expected doc counts