### PR TITLE
Refactor: consolidate constants, remove legacy field fallbacks, standardize store conventions

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -70,7 +70,7 @@
           <v-list-item-title>Головна</v-list-item-title>
         </v-list-item>
 
-        <v-list-item tag="router-link" :to="'/islands/island_rock'" @click="drawer = false">
+        <v-list-item tag="router-link" :to="`/islands/${DEFAULT_ISLAND_ID}`" @click="drawer = false">
           <v-list-item-icon><v-icon>mdi-island</v-icon></v-list-item-icon>
           <v-list-item-title>Острови</v-list-item-title>
         </v-list-item>
@@ -135,6 +135,7 @@
 import { useUserStore } from '../store/userStore';
 import { useRouter } from 'vue-router';
 import { ref, computed } from 'vue';
+import { DEFAULT_ISLAND_ID } from '../config/constants.js';
 
 const userStore = useUserStore();
 const router = useRouter();

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,0 +1,3 @@
+export const DEFAULT_ISLAND_ID = 'island_rock'
+
+export const PSEUDO_RELIGION_ID = 'psevdo'

--- a/src/config/religion.js
+++ b/src/config/religion.js
@@ -1,0 +1,6 @@
+export const BUILDING_LEVEL_BONUSES = {
+  none:      { svBonus: 0, passiveFaith: 0  },
+  chapel:    { svBonus: 1, passiveFaith: 20 },
+  temple:    { svBonus: 2, passiveFaith: 40 },
+  cathedral: { svBonus: 3, passiveFaith: 60 },
+}

--- a/src/services/cycleService.js
+++ b/src/services/cycleService.js
@@ -17,20 +17,10 @@ import {
 import { diffInDays, formatFaerunDate, normalizeFaerunDate, parseFaerunDate } from '../utils/faerun-date.js'
 import { db } from './firebase.js'
 import { formatAmount } from '../utils/formatters.js'
+import { normalizeAmount } from '../utils/numbers.js'
+import { BUILDING_LEVEL_BONUSES } from '../config/religion.js'
+import { DEFAULT_ISLAND_ID } from '../config/constants.js'
 import { generateSpellRequestsForCycle, settlePreviousSpellRequests } from './mageGuildService.js'
-
-const BUILDING_LEVEL_BONUSES = {
-  none: { passiveFaith: 0 },
-  chapel: { passiveFaith: 20 },
-  temple: { passiveFaith: 40 },
-  cathedral: { passiveFaith: 60 },
-}
-
-function normalizeAmount(value) {
-  const parsed = Number(value)
-  if (!Number.isFinite(parsed)) return 0
-  return Math.round(parsed * 100) / 100
-}
 
 function normalizeIncomeDestination(value) {
   if (typeof value !== 'string') return 'treasury'
@@ -112,7 +102,7 @@ export async function distributeManufactureIncome(cycleId, startedAt, finishedAt
   serverTimestamp: serverTimestampFn = serverTimestamp,
   db: firestoreDb = db,
 } = {}) {
-  const islandSnap = await getDocFn(docFn(firestoreDb, 'islands', islandId || 'island_rock'))
+  const islandSnap = await getDocFn(docFn(firestoreDb, 'islands', islandId || DEFAULT_ISLAND_ID))
   if (!islandSnap.exists()) return
 
   const manufactureIds = Array.isArray(islandSnap.data()?.manufactures) ? islandSnap.data().manufactures : []
@@ -120,8 +110,8 @@ export async function distributeManufactureIncome(cycleId, startedAt, finishedAt
   const entries = (await loadManufacturesByIds(manufactureIds, loadDeps)).filter((item) => item.income !== 0)
   const populationEntries = (populationItems || [])
     .map((group) => {
-      const count = Number(group.count ?? group.amount ?? 0)
-      const incomePerPerson = normalizeAmount(group.incomePerPerson ?? group.income ?? group.incomePer ?? 0)
+      const count = Number(group.count ?? 0)
+      const incomePerPerson = normalizeAmount(group.incomePerPerson ?? 0)
       return {
         id: group.id,
         name: group.name || 'Невідома група',
@@ -279,7 +269,7 @@ export async function distributeBuildingFaithIncome(cycleId, {
 export async function createNewCycleWithEffects({
   startedDate,
   notes = '',
-  islandId = 'island_rock',
+  islandId = DEFAULT_ISLAND_ID,
   population = 0,
   populationItems = [],
 }, {

--- a/src/services/mageGuildService.js
+++ b/src/services/mageGuildService.js
@@ -122,7 +122,7 @@ function sortRequests(requests = []) {
 }
 
 function getIslandPopulationValue(data = {}) {
-  return Number(data.population ?? data.populationCount ?? data.people ?? 0) || 0
+  return Number(data.population ?? 0) || 0
 }
 
 async function resolvePopulation(islandId, fallbackPopulation) {

--- a/src/store/interestGroupStore.js
+++ b/src/store/interestGroupStore.js
@@ -16,13 +16,13 @@ export const useInterestGroupStore = defineStore('interestGroup', () => {
         islandId: null,
     })
 
-    function stopListener() {
+    function stopListening() {
         if (state._unsubGroups) { state._unsubGroups(); state._unsubGroups = null }
         if (state._unsubIsland) { state._unsubIsland(); state._unsubIsland = null }
     }
 
-    function startListener(islandId) {
-        stopListener()
+    function startListening(islandId) {
+        stopListening()
         state.loading = true
         state.error = null
         state.islandId = islandId || null
@@ -47,7 +47,7 @@ export const useInterestGroupStore = defineStore('interestGroup', () => {
             const islandRef = doc(db, 'islands', islandId)
             state._unsubIsland = onSnapshot(islandRef, (snap) => {
                 const data = snap.data() || {}
-                const pop = data.population ?? data.populationCount ?? data.people ?? 0
+                const pop = data.population ?? 0
                 state.totalPopulation = Number(pop) || 0
             }, (err) => {
                 console.error('[interestGroup] island error:', err)
@@ -85,8 +85,8 @@ export const useInterestGroupStore = defineStore('interestGroup', () => {
 
     return {
         ...toRefs(state),
-        startListener,
-        stopListener,
+        startListening,
+        stopListening,
         totalPopulation,
         totalCountFromGroups,
         groupsAugmented,

--- a/src/store/islandStore.js
+++ b/src/store/islandStore.js
@@ -4,10 +4,11 @@ import { ref, computed } from 'vue'
 import {
     getFirestore, doc, onSnapshot, updateDoc, getDoc,
 } from 'firebase/firestore'
+import { DEFAULT_ISLAND_ID } from '@/config/constants.js'
 
 export const useIslandStore = defineStore('islands', () => {
     const db = getFirestore()
-    const currentId = ref('island_rock')
+    const currentId = ref(DEFAULT_ISLAND_ID)
     const data = ref(null)
     const loading = ref(false)
     const error = ref(null)

--- a/src/store/populationStore.js
+++ b/src/store/populationStore.js
@@ -4,6 +4,7 @@ import { reactive, computed, toRefs } from 'vue'
 import {
     getFirestore, collection, query, orderBy, onSnapshot, doc, updateDoc
 } from 'firebase/firestore'
+import { normalizeAmount } from '@/utils/numbers.js'
 
 export const usePopulationStore = defineStore('population', () => {
     const state = reactive({
@@ -16,13 +17,13 @@ export const usePopulationStore = defineStore('population', () => {
         islandId: null,
     })
 
-    function stopListener() {
+    function stopListening() {
         if (state._unsubGroups) { state._unsubGroups(); state._unsubGroups = null }
         if (state._unsubIsland) { state._unsubIsland(); state._unsubIsland = null }
     }
 
-    function startListener(islandId) {
-        stopListener()
+    function startListening(islandId) {
+        stopListening()
         state.loading = true
         state.error = null
         state.islandId = islandId || null
@@ -39,8 +40,7 @@ export const usePopulationStore = defineStore('population', () => {
                     return {
                         id: d.id,
                         ...data,
-                        // Перекладаємо поле amount => count для графіка
-                        count: data.count ?? data.amount ?? 0,
+                        count: Number(data.count ?? 0),
                     }
                 })
                 // Підтримка острівних даних, але не ховаємо глобальні записи без islandId
@@ -60,7 +60,7 @@ export const usePopulationStore = defineStore('population', () => {
             const islandRef = doc(db, 'islands', islandId)
             state._unsubIsland = onSnapshot(islandRef, (snap) => {
                 const data = snap.data() || {}
-                const pop = data.population ?? data.populationCount ?? data.people ?? 0
+                const pop = data.population ?? 0
                 state.totalPopulation = Number(pop) || 0
             }, (err) => {
                 console.error('[population] island error:', err)
@@ -75,21 +75,15 @@ export const usePopulationStore = defineStore('population', () => {
         if (!id) throw new Error('id is required')
         const value = Math.max(0, Number(count) || 0)
         const ref = doc(getFirestore(), 'population', id)
-        await updateDoc(ref, { count: value, amount: value })
+        await updateDoc(ref, { count: value })
     }
 
     const totalCountFromGroups = computed(() =>
         state.items.reduce((s, g) => s + (g.count || 0), 0)
     )
 
-    const normalizeIncome = (value) => {
-        const parsed = Number(value)
-        if (!Number.isFinite(parsed)) return 0
-        return Math.round(parsed * 100) / 100
-    }
-
-    const groupIncomePerPerson = (group) => normalizeIncome(
-        group?.incomePerPerson ?? group?.income ?? group?.incomePer ?? 0
+    const groupIncomePerPerson = (group) => normalizeAmount(
+        group?.incomePerPerson ?? 0
     )
 
     // Беремо total з islands; якщо 0 — fallback на суму груп
@@ -102,7 +96,7 @@ export const usePopulationStore = defineStore('population', () => {
             const count = Number(group.count || 0)
             return sum + groupIncomePerPerson(group) * count
         }, 0)
-        return normalizeIncome(total)
+        return normalizeAmount(total)
     })
 
     // Збагачені елементи: percent + votes (із 10)
@@ -112,7 +106,7 @@ export const usePopulationStore = defineStore('population', () => {
             const percent = (g.count || 0) / total * 100
             const votes   = (percent / 100) * 10
             const incomePerPerson = groupIncomePerPerson(g)
-            const incomeTotal = normalizeIncome(incomePerPerson * (g.count || 0))
+            const incomeTotal = normalizeAmount(incomePerPerson * (g.count || 0))
             return {
                 ...g,
                 percent,                        // напр. 50.0
@@ -127,8 +121,8 @@ export const usePopulationStore = defineStore('population', () => {
 
     return {
         ...toRefs(state),
-        startListener,
-        stopListener,
+        startListening,
+        stopListening,
         totalPopulation,
         totalCountFromGroups,
         populationIncomeTotal,

--- a/src/store/religionStore.js
+++ b/src/store/religionStore.js
@@ -12,6 +12,8 @@ import {
   runTransaction,
 } from 'firebase/firestore'
 import { db } from '@/services/firebase'
+import { BUILDING_LEVEL_BONUSES } from '@/config/religion.js'
+import { PSEUDO_RELIGION_ID } from '@/config/constants.js'
 
 export const DEFAULT_VALUES = {
   farmBase: 10,
@@ -22,24 +24,7 @@ export const DEFAULT_VALUES = {
   svTemp: 0,
 };
 
-export const BUILDING_LEVEL_BONUSES = {
-  none: {
-    svBonus: 0,
-    passiveFaith: 0,
-  },
-  chapel: {
-    svBonus: 1,
-    passiveFaith: 20,
-  },
-  temple:  {
-    svBonus: 2,
-    passiveFaith: 40,
-  },
-  cathedral: {
-    svBonus: 3,
-    passiveFaith: 60,
-  },
-}
+export { BUILDING_LEVEL_BONUSES }
 
 function getTempSV(data) {
   const svTemp = Number(data.svTemp ?? DEFAULT_VALUES.svTemp)
@@ -155,7 +140,6 @@ export const useReligionStore = defineStore('religion', () => {
           resolveHero(heroRef, heroCache, 'Невідомий герой'),
           resolveName(religionRef, religionCache, 'Невідома релігія'),
         ])
-            // [{"id":"Ashkarot","name":"Ашкарот","followers":0},{"id":"Asmodei","name":"Девіл","followers":66},{"id":"Blibdoolpoolp","name":"Блібдулпулп","followers":1},{"id":"Godless","name":"Атеїзм","followers":10},{"id":"Istishia","name":"Істишія","followers":1},{"id":"Panzuriel","name":"Панцуріель","followers":5},{"id":"Umberlee","name":"Амберлі","followers":27},{"id":"Unknown","name":"Не визначено","followers":86},{"id":"quadro","name":"Четвірка","followers":37},{"id":"test","name":"test religion","followers":12},{"id":"trio","name":"Трійка","followers":130}]
 
         if (hero.inactive) return null
 
@@ -194,7 +178,7 @@ export const useReligionStore = defineStore('religion', () => {
 
     religionUnsubscribe = onSnapshot(religionsRef, (snapshot) => {
       religions.value = snapshot.docs
-        .filter((docSnap) => docSnap.id !== 'psevdo')
+        .filter((docSnap) => docSnap.id !== PSEUDO_RELIGION_ID)
         .map((docSnap) => {
         const data = docSnap.data() || {}
         return {
@@ -305,18 +289,6 @@ export const useReligionStore = defineStore('religion', () => {
     })
   }
 
-  function setDowntimeAvailability(clergyId, downtimeAvailable) {
-    const index = records.value.findIndex((item) => item.id === clergyId)
-    if (index === -1) return
-
-    const updated = { ...records.value[index], downtimeAvailable }
-    records.value = [
-      ...records.value.slice(0, index),
-      updated,
-      ...records.value.slice(index + 1),
-    ]
-  }
-
   return {
     records,
     loading,
@@ -330,7 +302,6 @@ export const useReligionStore = defineStore('religion', () => {
     listenLogs,
     stopLogs,
     changeFaith,
-    setDowntimeAvailability,
     abilities,
   }
 })

--- a/src/store/treasuryStore.js
+++ b/src/store/treasuryStore.js
@@ -1,141 +1,150 @@
-import { defineStore } from "pinia";
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
 import {
-    getFirestore, doc, collection, query, orderBy, limit, startAfter,
-    getDocs, onSnapshot, runTransaction, serverTimestamp
-} from "firebase/firestore";
+  getFirestore, doc, collection, query, orderBy, limit, startAfter,
+  getDocs, onSnapshot, runTransaction, serverTimestamp,
+} from 'firebase/firestore'
+import { normalizeAmount } from '../utils/numbers.js'
 
 // Exported for testing. Accepts injectable firebase deps so the transaction
 // logic can be verified without a real Firestore connection.
 export async function applyTreasuryTransaction(
-    { delta, type, comment, user },
-    {
-        runTransactionFn = runTransaction,
-        docFn = doc,
-        collectionFn = collection,
-        serverTimestampFn = serverTimestamp,
-        db: firestoreDb,
-    } = {},
+  { delta, type, comment, user },
+  {
+    runTransactionFn = runTransaction,
+    docFn = doc,
+    collectionFn = collection,
+    serverTimestampFn = serverTimestamp,
+    db: firestoreDb,
+  } = {},
 ) {
-    const db = firestoreDb ?? getFirestore();
-    const metaRef = docFn(db, "treasury/meta");
-    const txCol = collectionFn(db, "treasury-transactions");
+  const db = firestoreDb ?? getFirestore()
+  const metaRef = docFn(db, 'treasury/meta')
+  const txCol = collectionFn(db, 'treasury-transactions')
 
-    await runTransactionFn(db, async (t) => {
-        const metaSnap = await t.get(metaRef);
-        const metaData = metaSnap.exists() ? metaSnap.data() : {};
-        const current = metaData.balance || 0;
-        const newBalance = current + delta;
+  await runTransactionFn(db, async (t) => {
+    const metaSnap = await t.get(metaRef)
+    const metaData = metaSnap.exists() ? metaSnap.data() : {}
+    const current = metaData.balance || 0
+    const newBalance = current + delta
 
-        if (newBalance < 0) throw new Error("Недостатньо золота у скарбниці.");
+    if (newBalance < 0) throw new Error('Недостатньо золота у скарбниці.')
 
-        const txRef = docFn(txCol);
-        t.set(txRef, {
-            amount: delta,
-            type,
-            comment: (comment || "").slice(0, 500),
-            userId: user?.uid || "anon",
-            nickname: (user?.nickname || "Гравець").slice(0, 80),
-            createdAt: serverTimestampFn(),
-            balanceAfter: newBalance,
-        });
-        t.set(metaRef, { balance: newBalance, updatedAt: serverTimestampFn() }, { merge: true });
-    });
+    const txRef = docFn(txCol)
+    t.set(txRef, {
+      amount: delta,
+      type,
+      comment: (comment || '').slice(0, 500),
+      userId: user?.uid || 'anon',
+      nickname: (user?.nickname || 'Гравець').slice(0, 80),
+      createdAt: serverTimestampFn(),
+      balanceAfter: newBalance,
+    })
+    t.set(metaRef, { balance: newBalance, updatedAt: serverTimestampFn() }, { merge: true })
+  })
 }
 
-export const useTreasuryStore = defineStore("treasury", {
-    state: () => ({
-        balance: 0,
-        totalIncome: 0,
-        totalOutcome: 0,
-        tx: [],
-        _lastDoc: null,
-        _pageSize: 20,
-        loading: false,
-        error: null,
-        _unsubMeta: null,
-    }),
-    actions: {
-        // Живий баланс із meta
-        subscribeBalance() {
-            if (this._unsubMeta) return;
-            const db = getFirestore();
-            const metaRef = doc(db, "treasury/meta");
-            this._unsubMeta = onSnapshot(metaRef, (snap) => {
-                if (snap.exists()) {
-                    const data = snap.data();
-                    this.balance = data.balance || 0;
-                    this.totalIncome = data.totalIncome || 0;
-                    this.totalOutcome = data.totalOutcome || 0;
-                } else {
-                    this.balance = 0;
-                    this.totalIncome = 0;
-                    this.totalOutcome = 0;
-                }
-            });
-        },
-        unsubscribeBalance() {
-            this._unsubMeta?.();
-            this._unsubMeta = null;
-        },
+export const useTreasuryStore = defineStore('treasury', () => {
+  const balance = ref(0)
+  const totalIncome = ref(0)
+  const totalOutcome = ref(0)
+  const tx = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+  const _pageSize = 20
+  let _lastDoc = null
+  let _unsubMeta = null
 
-        async loadFirstPage() {
-            this.loading = true; this.error = null;
-            try {
-                const db = getFirestore();
-                const q = query(
-                    collection(db, "treasury-transactions"),
-                    orderBy("createdAt", "desc"),
-                    limit(this._pageSize)
-                );
-                const snap = await getDocs(q);
-                this.tx = snap.docs.map(d => ({ id: d.id, ...d.data() }));
-                this._lastDoc = snap.docs[snap.docs.length - 1] || null;
-            } catch (e) {
-                this.error = e?.message || String(e);
-            } finally { this.loading = false; }
-        },
+  function subscribeBalance() {
+    if (_unsubMeta) return
+    const db = getFirestore()
+    const metaRef = doc(db, 'treasury/meta')
+    _unsubMeta = onSnapshot(metaRef, (snap) => {
+      if (snap.exists()) {
+        const data = snap.data()
+        balance.value = data.balance || 0
+        totalIncome.value = data.totalIncome || 0
+        totalOutcome.value = data.totalOutcome || 0
+      } else {
+        balance.value = 0
+        totalIncome.value = 0
+        totalOutcome.value = 0
+      }
+    })
+  }
 
-        async loadNextPage() {
-            if (!this._lastDoc) return;
-            this.loading = true; this.error = null;
-            try {
-                const db = getFirestore();
-                const q = query(
-                    collection(db, "treasury-transactions"),
-                    orderBy("createdAt", "desc"),
-                    startAfter(this._lastDoc),
-                    limit(this._pageSize)
-                );
-                const snap = await getDocs(q);
-                this.tx.push(...snap.docs.map(d => ({ id: d.id, ...d.data() })));
-                this._lastDoc = snap.docs[snap.docs.length - 1] || null;
-            } catch (e) {
-                this.error = e?.message || String(e);
-            } finally { this.loading = false; }
-        },
+  function unsubscribeBalance() {
+    _unsubMeta?.()
+    _unsubMeta = null
+  }
 
-        async _applyTx({ delta, type, comment, user }) {
-            await applyTreasuryTransaction({ delta, type, comment, user });
-        },
-
-        // Публічні методи
-        async deposit({ amount, comment, user }) {
-            const delta = roundAmount(amount);
-            if (!delta || delta <= 0) throw new Error("Сума має бути більшою за 0.");
-            await this._applyTx({ delta, type: "deposit", comment, user });
-        },
-
-        async withdraw({ amount, comment, user }) {
-            const deltaAbs = roundAmount(amount);
-            if (!deltaAbs || deltaAbs <= 0) throw new Error("Сума має бути більшою за 0.");
-            const delta = -deltaAbs; // зняття — від’ємне
-            await this._applyTx({ delta, type: "withdraw", comment, user });
-        },
+  async function loadFirstPage() {
+    loading.value = true
+    error.value = null
+    try {
+      const db = getFirestore()
+      const q = query(
+        collection(db, 'treasury-transactions'),
+        orderBy('createdAt', 'desc'),
+        limit(_pageSize),
+      )
+      const snap = await getDocs(q)
+      tx.value = snap.docs.map((d) => ({ id: d.id, ...d.data() }))
+      _lastDoc = snap.docs[snap.docs.length - 1] || null
+    } catch (e) {
+      error.value = e?.message || String(e)
+    } finally {
+      loading.value = false
     }
-});
+  }
 
-function roundAmount(value) {
-    const parsed = Number(value || 0);
-    if (!Number.isFinite(parsed)) return 0;
-    return Math.round(parsed * 100) / 100;
-}
+  async function loadNextPage() {
+    if (!_lastDoc) return
+    loading.value = true
+    error.value = null
+    try {
+      const db = getFirestore()
+      const q = query(
+        collection(db, 'treasury-transactions'),
+        orderBy('createdAt', 'desc'),
+        startAfter(_lastDoc),
+        limit(_pageSize),
+      )
+      const snap = await getDocs(q)
+      tx.value.push(...snap.docs.map((d) => ({ id: d.id, ...d.data() })))
+      _lastDoc = snap.docs[snap.docs.length - 1] || null
+    } catch (e) {
+      error.value = e?.message || String(e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function deposit({ amount, comment, user }) {
+    const delta = normalizeAmount(amount)
+    if (!delta || delta <= 0) throw new Error('Сума має бути більшою за 0.')
+    await applyTreasuryTransaction({ delta, type: 'deposit', comment, user })
+  }
+
+  async function withdraw({ amount, comment, user }) {
+    const deltaAbs = normalizeAmount(amount)
+    if (!deltaAbs || deltaAbs <= 0) throw new Error('Сума має бути більшою за 0.')
+    const delta = -deltaAbs
+    await applyTreasuryTransaction({ delta, type: 'withdraw', comment, user })
+  }
+
+  return {
+    balance,
+    totalIncome,
+    totalOutcome,
+    tx,
+    loading,
+    error,
+    subscribeBalance,
+    unsubscribeBalance,
+    loadFirstPage,
+    loadNextPage,
+    deposit,
+    withdraw,
+  }
+})

--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -1,0 +1,9 @@
+/**
+ * Round a numeric value to 2 decimal places.
+ * Returns 0 for non-finite inputs.
+ */
+export function normalizeAmount(value) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 0
+  return Math.round(parsed * 100) / 100
+}

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -390,6 +390,7 @@ import { usePopulationStore } from '@/store/populationStore';
 import { createNewCycleWithEffects } from '@/services/cycleService';
 import CraftActionForm from '@/components/crafting/CraftActionForm.vue';
 import { loadCraftItems } from '@/services/craftingService';
+import { DEFAULT_ISLAND_ID } from '@/config/constants.js';
 
 const logEntries = ref([]);
 const cycleSaving = ref(false);
@@ -654,7 +655,7 @@ async function createCycle() {
     await createNewCycleWithEffects({
       startedDate: cycleForm.startedDate,
       notes: cycleForm.notes,
-      islandId: islandStore.currentId || 'island_rock',
+      islandId: islandStore.currentId || DEFAULT_ISLAND_ID,
       population: populationStore.totalPopulation,
       populationItems: populationStore.items || [],
     });
@@ -1112,7 +1113,7 @@ watch(heroRows, (rows) => {
 }, { immediate: true });
 
 onMounted(async () => {
-  populationStore.startListener(islandStore.currentId || 'island_rock');
+  populationStore.startListening(islandStore.currentId || DEFAULT_ISLAND_ID);
   const q = query(collection(db, 'logs'), orderBy('timestamp', 'desc'));
   const snapshot = await getDocs(q);
   logEntries.value = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
@@ -1123,7 +1124,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  populationStore.stopListener();
+  populationStore.stopListening();
   stopHeroes?.();
   stopReligions?.();
   stopClergy?.();

--- a/src/views/BuildingsPage.vue
+++ b/src/views/BuildingsPage.vue
@@ -36,8 +36,9 @@ import { useDonationGoalStore } from '@/store/donationGoalStore'
 import { useUserStore } from '@/store/userStore.js'
 import IslandBuildingDialog from "@/components/IslandBuildingDialog.vue";
 import {storeToRefs} from "pinia";
+import { DEFAULT_ISLAND_ID } from '@/config/constants.js';
 
-const islandImg = '/images/island/island_rock.jpg'
+const islandImg = `/images/island/${DEFAULT_ISLAND_ID}.jpg`
 const pins = [
   { id: 'arcaneStudy',   top: 307, left:  73 },
   { id: 'armory',        top: 280, left: 480 },
@@ -71,7 +72,7 @@ const { data: island } = storeToRefs(islandStore)
 const isAdmin = computed(() => auth?.isAdmin ?? false)
 
 onMounted(() => {
-  islandStore.subscribe('island_rock')
+  islandStore.subscribe()
   buildingStore.subscribe()
   donationStore.subscribeToGoals?.() // існуючий listener для донатів
 })

--- a/src/views/IslandInfoPage.vue
+++ b/src/views/IslandInfoPage.vue
@@ -42,7 +42,7 @@ const form = reactive({
 })
 
 onMounted(() => {
-  islandStore.subscribe('island_rock')
+  islandStore.subscribe()
 })
 onUnmounted(() => {
   islandStore.stop()

--- a/src/views/IslandsPage.vue
+++ b/src/views/IslandsPage.vue
@@ -87,7 +87,7 @@ const { data: island } = storeToRefs(islandStore)
 const isAdmin = computed(() => auth?.isAdmin ?? false)
 
 onMounted(() => {
-  islandStore.subscribe('island_rock')
+  islandStore.subscribe()
   buildingStore.subscribe()
   donationStore.subscribeToGoals?.() // існуючий listener для донатів
 })

--- a/src/views/MageGuildPage.vue
+++ b/src/views/MageGuildPage.vue
@@ -343,7 +343,7 @@ watch(() => store.requestDocuments, (docs) => {
 watch(
   () => islandStore.currentId,
   async (id) => {
-    populationStore.startListener(id)
+    populationStore.startListening(id)
     await ensureCurrentCycleRequests()
   },
   { immediate: true },
@@ -355,7 +355,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   store.stopListening()
-  populationStore.stopListener()
+  populationStore.stopListening()
 })
 </script>
 

--- a/src/views/PoliticsPage.vue
+++ b/src/views/PoliticsPage.vue
@@ -228,7 +228,7 @@ let unsubProposals, unsubInterests;
 // =================== SUBSCRIPTIONS ============
 onMounted(() => {
   // Groups (наприклад: sailors/peasants/workers)
-  interestGroupStore.startListener();
+  interestGroupStore.startListening();
 
   // Proposals
   const base = collection(db, 'proposals');
@@ -253,7 +253,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   unsubProposals && unsubProposals();
   unsubInterests && unsubInterests();
-  interestGroupStore.stopListener();
+  interestGroupStore.stopListening();
 });
 
 // =================== HELPERS ==================

--- a/src/views/PopulationPage.vue
+++ b/src/views/PopulationPage.vue
@@ -133,13 +133,13 @@ const islandStore = useIslandStore()
 const userStore = useUserStore()
 
 onMounted(() => {
-  store.startListener(islandStore.currentId)
+  store.startListening(islandStore.currentId)
   console.log(islandStore.currentId)
 });
-onBeforeUnmount(() => store.stopListener())
+onBeforeUnmount(() => store.stopListening())
 
 watch(() => islandStore.currentId, (id) => {
-  store.startListener(id)
+  store.startListening(id)
 })
 
 const totalPopulation = computed(() => store.totalPopulation)

--- a/src/views/ReligionPage.vue
+++ b/src/views/ReligionPage.vue
@@ -281,6 +281,7 @@ import ReligionAbilitiesTable from '@/components/ReligionAbilitiesTable.vue'
 import ReligionTable from '@/components/ReligionTable.vue'
 import ReligionModals from '@/components/ReligionModals.vue'
 import { db } from '@/services/firebase'
+import { PSEUDO_RELIGION_ID } from '@/config/constants.js'
 import { formatAmount } from '@/utils/formatters'
 import { parseFaerunDate } from '@/utils/faerun-date'
 
@@ -345,20 +346,22 @@ function bonusTooltip(bonus) {
   if (bonus?.active === false) parts.push(bonus.hint || 'Бонус неактивний')
   return parts.join(' • ')
 }
+const RELIGION_META = {
+  Панцуріель:    { imageKey: 'Panzuriel',     color: '#000000', hasIcon: true  },
+  Амберлі:       { imageKey: 'Umberlee',       color: '#1e3a8a', hasIcon: true  },
+  Ашкарот:       { imageKey: 'Ashkarot',       color: null,      hasIcon: true  },
+  Девіл:         { imageKey: 'Devil',          color: '#8b0000', hasIcon: true  },
+  Блібдулпулп:   { imageKey: 'Blibdoolpoolp',  color: '#e8a77b', hasIcon: true  },
+  Істишія:       { imageKey: 'Istishia',       color: '#45d1ca', hasIcon: true  },
+  Трійка:        { imageKey: 'trio',           color: '#6a80d9', hasIcon: true  },
+  Четвірка:      { imageKey: 'quadro',         color: '#090070', hasIcon: true  },
+  'Не визначено': { imageKey: 'Unknown',        color: '#7e8694', hasIcon: false },
+  Відсутність:   { imageKey: 'Godless',        color: null,      hasIcon: false },
+  Атеїзм:        { imageKey: null,             color: '#fafcfc', hasIcon: false },
+}
+
 function hasIcon(name) {
-  switch (name) {
-    case 'Амберлі':
-    case 'Блібдулпулп':
-    case 'Панцуріель':
-    case 'Істишія':
-    case 'Девіл':
-    case 'Ашкарот':
-    case 'Трійка':
-    case 'Четвірка':
-      return true
-    default:
-      return false
-  }
+  return RELIGION_META[name]?.hasIcon ?? false
 }
 
 function getIconImage(name) {
@@ -370,21 +373,8 @@ function getIconImage(name) {
   return iconCache.get(name)
 }
 
-const religionImages = {
-  Панцуріель: 'Panzuriel',
-  Амберлі: 'Umberlee',
-  Ашкарот: 'Ashkarot',
-  Девіл: 'Devil',
-  'Не визначено': 'Unknown',
-  Відсутність: 'Godless',
-  Трійка: 'trio',
-  Четвірка: 'quadro',
-  Блібдулпулп: 'Blibdoolpoolp',
-  Істишія: 'Istishia'
-}
-
 function getCenterImage(name) {
-  return name ? religionImages[name] : 'Unknown';
+  return name ? (RELIGION_META[name]?.imageKey ?? 'Unknown') : 'Unknown'
 }
 
 const religionIconPlugin = {
@@ -439,14 +429,14 @@ onMounted(() => religionStore.startListening())
 onBeforeUnmount(() => religionStore.stopListening())
 
 onMounted(() => {
-  populationStore.startListener(islandStore.currentId)
+  populationStore.startListening(islandStore.currentId)
 })
 
-onBeforeUnmount(() => populationStore.stopListener())
+onBeforeUnmount(() => populationStore.stopListening())
 
 onMounted(loadLatestCycle)
 onMounted(() => {
-  const devaCustomRef = doc(db, 'religions', 'psevdo', 'customs', 'Deva')
+  const devaCustomRef = doc(db, 'religions', PSEUDO_RELIGION_ID, 'customs', 'Deva')
   devaCustomUnsubscribe = onSnapshot(devaCustomRef, (snap) => {
     devaCustom.value = snap.data() || {}
   })
@@ -739,23 +729,12 @@ const totalFollowersLabel = computed(() => {
 })
 
 const totalPopulationLabel = computed(() => (totalPopulation.value || 0).toLocaleString('uk-UA'))
-const religionColors = {
-  Панцуріель: '#000000',
-  Амберлі: '#1e3a8a',
-  Девіл: '#8b0000',
-  'Не визначено': '#7e8694',
-  Атеїзм: '#fafcfc',
-  Трійка: '#6a80d9',
-  Четвірка: '#090070',
-  Блібдулпулп: '#e8a77b',
-  Істишія: '#45d1ca'
-}
-
 const fallbackPalette = ['#c7d2fe', '#fbbf24', '#34d399', '#f472b6', '#60a5fa', '#f87171', '#a78bfa']
 const colorCache = new Map()
 
 function getReligionColor(name) {
-  if (religionColors[name]) return religionColors[name]
+  const meta = RELIGION_META[name]
+  if (meta?.color) return meta.color
 
   if (!colorCache.has(name)) {
     const index = colorCache.size % fallbackPalette.length
@@ -1020,7 +999,7 @@ const spreadReligionDisabled = computed(
 watch(
   () => islandStore.currentId,
   (id) => {
-    populationStore.startListener(id)
+    populationStore.startListening(id)
   },
 )
 
@@ -1268,7 +1247,7 @@ async function handleCycleDevaConsumption() {
   if (!current || !previous) return
   if (current.day !== 1 || (current.month === previous.month && current.year === previous.year)) return
 
-  const devaRef = doc(db, 'religions', 'psevdo', 'customs', 'Deva')
+  const devaRef = doc(db, 'religions', PSEUDO_RELIGION_ID, 'customs', 'Deva')
 
   await runTransaction(db, async (transaction) => {
     const snap = await transaction.get(devaRef)
@@ -1505,7 +1484,6 @@ async function saveDowntimeAvailability() {
 
   try {
     await updateDoc(heroRefValue, { downtimeAvailable: downtimeAvailable.value })
-    religionStore.setDowntimeAvailability(activeClergy.value.id, downtimeAvailable.value)
     downtimeUpdateSuccess.value = true
   } catch (e) {
     downtimeUpdateError.value = e?.message || 'Не вдалося оновити статус даутайму.'
@@ -1821,8 +1799,6 @@ async function applySpreadReligion() {
       }),
     ])
 
-    religionStore.setDowntimeAvailability(activeClergy.value.id, false)
-
     spreadReligionForm.roll = null
     spreadReligionForm.dmMod = 0
     spreadReligionForm.notes = ''
@@ -1974,8 +1950,6 @@ async function applyActiveFaithFarm() {
       }),
     ])
 
-    religionStore.setDowntimeAvailability(activeClergy.value.id, false)
-
     activeFaithFarmForm.roll = null
     activeFaithFarmForm.notes = ''
     activeFaithFarmForm.dmMod = 0
@@ -2001,7 +1975,7 @@ async function applyCelestialTransfer() {
   celestialTransferError.value = ''
   try {
     const clergyRef = doc(db, 'clergy', activeClergy.value.id)
-    const devaRef = doc(db, 'religions', 'psevdo', 'customs', 'Deva')
+    const devaRef = doc(db, 'religions', PSEUDO_RELIGION_ID, 'customs', 'Deva')
     await runTransaction(db, async (transaction) => {
       const clergySnapshot = await transaction.get(clergyRef)
       const devaSnapshot = await transaction.get(devaRef)

--- a/src/views/TreasuryPage.vue
+++ b/src/views/TreasuryPage.vue
@@ -92,7 +92,7 @@ async function loadManufactureTotals(ids) {
 
 onMounted(() => {
   loadManufactureTotals(island.value?.manufactures)
-  populationStore.startListener(islandStore.currentId)
+  populationStore.startListening(islandStore.currentId)
 })
 
 watch(
@@ -106,11 +106,11 @@ watch(
 watch(
   () => islandStore.currentId,
   (id) => {
-    populationStore.startListener(id)
+    populationStore.startListening(id)
   },
 )
 
-onBeforeUnmount(() => populationStore.stopListener())
+onBeforeUnmount(() => populationStore.stopListening())
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

- **New shared modules**: `src/utils/numbers.js` (`normalizeAmount`), `src/config/constants.js` (`DEFAULT_ISLAND_ID`, `PSEUDO_RELIGION_ID`), `src/config/religion.js` (`BUILDING_LEVEL_BONUSES`) — eliminates 3+ duplicate definitions each
- **Remove legacy field fallbacks**: `count??amount`, `incomePerPerson??income??incomePer`, `population??populationCount??people` across `populationStore`, `interestGroupStore`, `mageGuildService`, `cycleService`; also removes dual-write of `count+amount` in `setGroupCount`
- **Hardcoded ID cleanup**: `'island_rock'` (8 sites) and `'psevdo'` (3 sites) replaced with named constants
- **Listener naming**: `startListener`/`stopListener` → `startListening`/`stopListening` across `populationStore`, `interestGroupStore`, and 6 call-site views
- **religionStore cleanup**: delete stale JSON debug comment; remove redundant `setDowntimeAvailability` (snapshot listener already drives state)
- **treasuryStore**: converted from Options API to Composition API to match every other store
- **ReligionPage.vue**: three separate religion metadata structures (`religionImages`, `religionColors`, `hasIcon` switch) collapsed into one `RELIGION_META` map

## Test plan

- [ ] All 124 frontend tests pass (`npm test`)
- [ ] All 42 backend tests pass (`cd functions && npm test`)
- [ ] Smoke-test: island page loads, treasury deposit/withdraw works, religion page renders chart and colors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)