### PR TITLE
Docs: add hierarchical page documentation system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,165 @@ All Firestore collection and document shapes are defined as JSDoc typedefs in [`
 - Services: camelCase + `Service` suffix (`firestoreService`, `fishingService`)
 - No ESLint/Prettier configured — no linting step exists
 - Path alias `@/` resolves to `src/` (configured in `vite.config.mjs`)
+
+### Admin gate pattern
+Always use `computed(() => useUserStore().isAdmin ?? false)` — never read `isAdmin` directly in templates without the null-safe fallback.
+
+### Dialog UI pattern
+All dialogs follow the same structure: dark gradient card (`--wi-surface` → `--wi-bg` gradient) with `1px solid var(--wi-gold)` border, a custom header div (not `v-card-title`), `v-card-text` body, `v-divider`, and `v-card-actions` footer. The global theme in `src/styles/theme.css` applies this automatically to `.v-dialog .v-card` — avoid overriding it per-dialog.
+
+### Firestore access patterns
+- **Real-time data** (stores, live UI): use `onSnapshot` with a stop function stored and called in `onBeforeUnmount`
+- **One-time reads** (admin imports, initial load): use `getDocs`
+- **`in` query limit**: Firestore limits `where(field, 'in', array)` to 10 items — chunk larger arrays and run multiple queries
+
+### Image assets
+- `/public/images/buildings/{id}.png` — building pin images (referenced as `/images/buildings/…` at runtime)
+- `/public/images/island/{id}.jpg` — island map backgrounds
+- `src/images/` — source-bundled images imported via `@/images/…`
+
+## Design System
+
+The pirate theme lives in `src/styles/theme.css`. All Vuetify components are globally themed there — don't override base component styles per-page unless unavoidable.
+
+### CSS tokens
+| Token | Value | Use |
+|-------|-------|-----|
+| `--wi-bg` | `#1a1209` | Page background |
+| `--wi-surface` | `#2c1e0f` | Card/panel background |
+| `--wi-surface-hi` | `#3d2a14` | Elevated surface |
+| `--wi-gold` | `#c8962a` | Primary accent, headings |
+| `--wi-gold-light` | `#e8b84b` | Hover gold, borders |
+| `--wi-copper` | `#7b4f2e` | Secondary warm accent |
+| `--wi-text` | `#f0ddb0` | Body text |
+| `--wi-text-muted` | `#a8896a` | Secondary/label text |
+| `--wi-border` | `#5a3e20` | Borders, dividers |
+| `--wi-success` | `#5a8a3c` | Positive amounts, success states |
+| `--wi-danger` | `#8b2a2a` | Errors, negative amounts |
+| `--wi-sea` | `#3a6080` | Sea-themed accents |
+
+### Typography classes
+- `.wi-heading` — Cinzel serif, gold, letter-spacing (applied to `h1`–`h4` globally)
+- `.wi-number` — Cinzel Decorative, gold (currency amounts, large stats)
+- `.wi-mono` — Special Elite cursive
+- `.wi-parchment` — parchment-toned gradient background with border
+
+### Utility color classes
+`wi-gold-text`, `wi-muted-text`, `wi-sea-text`, `wi-danger-text`, `wi-success-text`
+
+> For detailed design guidance use the `west-islands-style` skill.
+
+## Shared Utilities & Constants
+
+### `src/config/constants.js`
+- `DEFAULT_ISLAND_ID` — `'island_rock'` — the single active island's Firestore document ID
+- `PSEUDO_RELIGION_ID` — `'psevdo'` — placeholder religion used for heroes with no religion assigned
+
+### `src/utils/formatters.js`
+- `formatAmount(value, decimals = 2)` — formats a number to fixed decimal string; returns `'0.00'` for non-finite values. Used for all currency display.
+
+### Faerun date utilities (`faerun-date` package + `src/utils/faerun-date.js`)
+- `parseFaerunDate(value)` — parses a stored date to `{ day, month, year }`
+- `normalizeFaerunDate(value)` — normalizes picker output to storable format
+- `diffInDays(dateA, dateB)` — difference in Faerun calendar days (360-day year, 12 months × 30 days)
+- `DEFAULT_YEAR` — the current campaign year constant
+
+## Testing
+
+Tests use Node's native test runner. All test files live in `tests/` mirroring the `src/` structure:
+
+```
+tests/
+├── services/   # authService, craftingService, cycleService, logService
+├── store/      # guildStore, treasuryStore, userStore
+└── utils/      # courierDistanceCalculator, faerun-date, mageGuildRequests, votes
+```
+
+Run a single file: `node --test tests/utils/votes.test.js`  
+Tests do **not** cover Vue components or pages — only services, stores, and utility functions.
+
+## Page Documentation
+
+Each page view has a companion `.md` file alongside its `.vue` file in `src/views/`. Complex pages with tabs or major sections have a sub-directory of per-tab/per-section files.
+
+### Island pages (nested under `/islands/:islandId`)
+- [IslandsPage.md](src/views/IslandsPage.md) — nav shell, plank-tab bar
+- [IslandInfoPage.md](src/views/IslandInfoPage.md) — island parameters, admin edit
+- [BuildingsPage.md](src/views/BuildingsPage.md) — interactive map, building pins
+- [PopulationPage.md](src/views/PopulationPage.md) — group cards, pie chart, admin edit dialog
+- [TreasuryPage.md](src/views/TreasuryPage.md) — chest card + transaction history
+- [ManufacturesPage.md](src/views/ManufacturesPage.md) — manufacture cards, admin CRUD
+
+### Standalone pages
+- [LoginView.md](src/views/LoginView.md) — auth flows, pirate-themed entry
+- [ShipsView.md](src/views/ShipsView.md) — fleet management, ship cards
+- [DonationGoalsPage.md](src/views/DonationGoalsPage.md) — fundraising goals, donor dialog
+- [ReligionPage.md](src/views/ReligionPage.md) — 4-mode view toggle
+  - [DiagramView.md](src/views/ReligionPage/DiagramView.md)
+  - [TableView.md](src/views/ReligionPage/TableView.md)
+  - [AbilitiesView.md](src/views/ReligionPage/AbilitiesView.md)
+  - [CelestialView.md](src/views/ReligionPage/CelestialView.md)
+- [PoliticsPage.md](src/views/PoliticsPage.md) — proposals, interest matrix, vote algorithm
+- [GuildsPage.md](src/views/GuildsPage.md) — guild cards, deposit/withdraw, ledger dialog
+- [MageGuildPage.md](src/views/MageGuildPage.md) — spell request cards, fulfillment, history panels
+- [CraftingPage.md](src/views/CraftingPage.md) — mastery tracker, price calculator
+- [TravelView.md](src/views/TravelView.md) — v-tabs container
+  - [ShipsTab.md](src/views/TravelView/ShipsTab.md)
+  - [CouriersTab.md](src/views/TravelView/CouriersTab.md)
+- [AdminView.md](src/views/AdminView.md) — admin panel sections
+  - [CyclesSection.md](src/views/AdminView/CyclesSection.md)
+  - [HeroesSection.md](src/views/AdminView/HeroesSection.md)
+  - [CampaignSummarySection.md](src/views/AdminView/CampaignSummarySection.md)
+  - [CraftingSection.md](src/views/AdminView/CraftingSection.md)
+
+## Creating a New Page
+
+### 1. Create the Vue component
+
+Add `src/views/YourPageName.vue`. Follow existing page patterns:
+- Use `<v-container>` as the root element
+- Apply pirate design tokens (`--wi-gold`, `--wi-font-heading`, `--wi-border`, etc.)
+- Use `useUserStore().isAdmin` to gate admin-only UI
+- Subscribe to stores in `onMounted`, unsubscribe in `onUnmounted`/`onBeforeUnmount`
+
+### 2. Register the route
+
+Add to `router/index.js`:
+
+```js
+import YourPageName from '@/views/YourPageName.vue';
+
+// In routes array:
+{ path: '/your-path', component: YourPageName, meta: { requiresAuth: false } }
+// or for admin-only:
+{ path: '/your-path', component: YourPageName, meta: { adminOnly: true } }
+```
+
+Auth guard is already handled by `router.beforeEach()` — just set the correct meta flag.
+
+### 3. Add to Navbar
+
+Add a navigation entry in `src/components/Navbar.vue` if the page should be globally accessible.
+
+### 4. Create the companion `.md` file
+
+Create `src/views/YourPageName.md` alongside the `.vue` file. Document:
+- Route and auth meta
+- Purpose (one paragraph)
+- Sections/components rendered
+- Stores and services used
+- Admin vs user behavior differences
+- Any non-obvious patterns or constraints
+
+If the page introduces a new service or utility function, add tests for it under `tests/` mirroring the `src/` path.
+
+### 5. If the page has tabs or major sections
+
+Create a sub-directory `src/views/YourPageName/` with one `.md` per tab or section. Reference them from `YourPageName.md` with relative links.
+
+For `v-tabs` pages: name files after the tab value (e.g., `ShipsTab.md`, `CouriersTab.md`).  
+For section-based pages (like AdminView): name files after the section (e.g., `CyclesSection.md`).
+
+### 6. Update `CLAUDE.md`
+
+Add the new page to the **Page Documentation** section above, under the appropriate group (island pages or standalone pages), with a relative link to its `.md` file.

--- a/src/views/AdminView.md
+++ b/src/views/AdminView.md
@@ -1,0 +1,31 @@
+# AdminView
+
+Route: `/admin` — `adminOnly: true` (redirects to `/` if not admin).
+
+## Purpose
+Admin control panel. Single-page with multiple distinct functional sections separated by `v-divider`. No tabs — vertical scroll layout.
+
+## Sections
+| Section | Sub-file |
+|---------|----------|
+| Cycle management | [AdminView/CyclesSection.md](AdminView/CyclesSection.md) |
+| Heroes & clergy | [AdminView/HeroesSection.md](AdminView/HeroesSection.md) |
+| Campaign summary & D&D Beyond import | [AdminView/CampaignSummarySection.md](AdminView/CampaignSummarySection.md) |
+| Crafting | [AdminView/CraftingSection.md](AdminView/CraftingSection.md) |
+| Event log | last section — `logs` collection, ordered by `timestamp` desc, loaded once on mount |
+
+## Shared data subscriptions
+All started in `onMounted`, stopped in `onBeforeUnmount`:
+- `heroes` collection snapshot → `heroes.value`
+- `religions` collection snapshot → `religions.value`
+- `clergy` collection snapshot → `clergyRows.value`
+- `hero-balance-sync-logs` query snapshot (last 1000, ordered by `syncedAt` desc) → `heroBalanceSyncLogs.value`
+- `populationStore.startListening(islandId)`
+
+## Computed cross-section data
+- `heroRows` — heroes joined with clergy (religion, clergyId), sorted alphabetically
+- `religionOptions` — for hero form selects
+- `clergyByHeroId` / `religionById` — lookup maps
+
+## Styling
+Single `.admin-card` wrapping everything. Deep CSS overrides for Vuetify data tables, expansion panels, and inner cards to match the dark pirate theme.

--- a/src/views/AdminView/CampaignSummarySection.md
+++ b/src/views/AdminView/CampaignSummarySection.md
@@ -1,0 +1,25 @@
+# AdminView — Campaign Summary & D&D Beyond Import section
+
+## Purpose
+Import hero currency balances from a D&D Beyond JSON export and review the import preview before applying.
+
+## Import flow
+1. Paste JSON array into textarea
+2. Click **Preview Import** — validates rows, matches by `dndbeyondCharacterId`, computes deltas
+3. Review preview cards: matched heroes (with delta), unmatched snapshot rows, invalid rows, heroes missing from snapshot
+4. Click **Apply Import** — updates each matched hero's `balance`, `balanceDelta`, and related sync fields; writes a log entry to `hero-balance-sync-logs`
+
+## Validation rules
+- Each row must be an object with `characterId` (non-empty string), `status: 'success'`, and `balance` object
+- Duplicate `characterId` values block the apply button
+- Balance normalized to `{ cp, sp, gp, ep, pp }` all as numbers
+
+## Preview summary fields
+`totalRows`, `validRows`, `matchedRows`, `unmatchedRows`, `invalidRows`, `missingHeroesFromSnapshot`
+
+## Apply writes (per matched hero)
+- `heroes/{heroId}`: updates `balance`, `balanceDelta`, `balanceSyncedAt`, `balanceSyncStatus: 'manual_import'`, `balanceSyncError: null`, `balanceSyncSource: 'manual_snapshot_import'`, `previousBalance`
+- `hero-balance-sync-logs`: new document with full import record
+
+## State (`snapshotImportState` reactive object)
+`rawInput`, `preview`, `error`, `applying`, `applySummary`

--- a/src/views/AdminView/CraftingSection.md
+++ b/src/views/AdminView/CraftingSection.md
@@ -1,0 +1,19 @@
+# AdminView — Crafting section
+
+## Purpose
+Admin shortcut to log a craft action for any hero without navigating to CraftingPage. Useful during sessions to quickly record what was crafted.
+
+## Component
+`CraftActionForm` (`src/components/crafting/CraftActionForm.vue`)
+
+Props passed from AdminView:
+- `heroes` — from `heroRows` computed (all heroes with names)
+- `items` — from `craftItemsForAdmin` (loaded via `loadCraftItems()`)
+- `defaultHeroId` — `selectedHeroIdForCrafting` (auto-set to first hero when heroes load)
+
+## Data loading
+`craftItemsForAdmin` is populated by `refreshCraftingAdminData()` which calls `loadCraftItems()` from `craftingService`. Called once on mount and again after a craft is saved (`@saved="refreshCraftingAdminData"`).
+
+## Notes
+- This section provides the same form as the dialog on CraftingPage but embedded inline in the admin panel
+- `selectedHeroIdForCrafting` is auto-initialized to `heroRows[0].id` via a watcher

--- a/src/views/AdminView/CyclesSection.md
+++ b/src/views/AdminView/CyclesSection.md
@@ -1,0 +1,23 @@
+# AdminView — Cycles section
+
+## Purpose
+Creates new game cycles (in-game time periods). Each cycle triggers downstream effects on religion, population income, and other systems.
+
+## Fields
+- **Початок нового циклу** — `FaerunDatePicker` (Forgotten Realms calendar date)
+- **Тривалість попереднього циклу** — read-only, computed as `diffInDays(previousCycleStart, newStart)` in Faerun days
+- **Нотатки до дії** — free text notes saved with the cycle
+
+## Suggested date
+On mount, `suggestNextCycleDate()` pre-fills the date picker with the previous cycle start + 7 Faerun days (one week). Uses modular arithmetic to handle month/year rollovers in the 360-day Faerun calendar.
+
+## Create cycle flow
+1. Validate: date must be set and after previous cycle start
+2. Call `createNewCycleWithEffects()` from `cycleService.js` — this is the authoritative function that applies all cycle side-effects (religion distributions, treasury credits, etc.)
+3. Reload `latestCycle` and re-suggest next date
+4. Show success/error alert
+
+## Data
+- `latestCycle` — loaded once on mount via `getDocs` query (latest by `createdAt`)
+- `islandStore.currentId` — passed to `createNewCycleWithEffects`
+- `populationStore.totalPopulation` / `.items` — passed to `createNewCycleWithEffects`

--- a/src/views/AdminView/HeroesSection.md
+++ b/src/views/AdminView/HeroesSection.md
@@ -1,0 +1,28 @@
+# AdminView — Heroes section
+
+## Purpose
+CRUD for heroes and their linked clergy records. Also shows hero balance snapshot history.
+
+## Hero table
+`v-data-table` with columns: name, religion, downtime status, active/inactive status, edit action.  
+Rows from `heroRows` computed — heroes joined with clergy (religion name, clergyId).
+
+## Add hero form
+Fields: name, religion (select), dndbeyondCharacterId.  
+On save: Firestore transaction that atomically creates both the `heroes` document and a `clergy` document linking hero to religion. Initial clergy state: `faith: 0, faithMax: 0`.
+
+## Edit hero dialog (`heroEditDialog`)
+Fields same as add form + `downtimeAvailable` switch + `inactive` switch.  
+On save: transaction that updates `heroes` doc and updates (or creates if missing) the linked `clergy` doc's religion reference.
+
+## Balance snapshot history table
+Shows last N snapshots (configurable: 5/10/20/50) from `hero-balance-sync-logs` collection.  
+Snapshots are grouped by `snapshotGroupKey` — built as `snapshot-{source}-{minuteBucket}` where minuteBucket = `floor(syncedAt.toMillis() / 60000)`. This groups logs from the same import session into one column.  
+Columns are sorted newest-first, sliced to limit. Rows = heroes, cells = balance + delta per snapshot.
+
+## Campaign summary card
+Aggregates current balances and deltas across all heroes. All 5 D&D currencies: CP, SP, GP, EP, PP. Delta values color-coded: positive = success, negative = error.
+
+## Key data
+- `heroes`, `religions`, `clergyRows`, `heroBalanceSyncLogs` — all real-time snapshots (see AdminView.md)
+- `snapshotHistoryLimit` — local ref, controls how many snapshot columns display

--- a/src/views/BuildingsPage.md
+++ b/src/views/BuildingsPage.md
@@ -1,0 +1,34 @@
+# BuildingsPage
+
+Route: `/islands/:islandId/buildings` (child of IslandsPage).
+
+## Purpose
+Interactive island map with clickable building pins. Each pin represents a building slot; clicking opens `IslandBuildingDialog` for details or admin actions.
+
+## Building pins
+21 hardcoded pins with pixel-precise `top`/`left` positions on an 800px-wide map image. Each pin has:
+- `id` — building key (e.g., `arcaneStudy`, `harbor`, `lighthouse`)
+- `top`, `left` — absolute px offset on the map
+- `flipX` — mirrors the pin image horizontally (for portCrane, shipyardBig)
+
+Pin images: `/images/buildings/{id}.png`  
+Map image: `/images/island/{DEFAULT_ISLAND_ID}.jpg`
+
+## Built vs unbuilt state
+`island.value.buildings` is a map of `{ [buildingKey]: { built: boolean } }`. Built pins glow gold; unbuilt pins are grayscale/faded. Hovering any pin scales it to 2.1× with a gold border.
+
+## Dialog
+`IslandBuildingDialog` receives:
+- `building-key` — the clicked pin id
+- `nickname` — from `userStore`
+- `is-admin` — from `userStore`
+
+## Stores
+- `islandStore` — island data (subscribed by parent IslandsPage)
+- `buildingStore` — building metadata (`byId` map for names)
+- `donationGoalStore` — subscribed by parent, available here
+
+## Adding a new building
+1. Add pin entry to the `pins` array with correct coordinates and id
+2. Add building image to `/public/images/buildings/{id}.png`
+3. Update `buildingStore` data and Firestore schema if needed

--- a/src/views/CraftingPage.md
+++ b/src/views/CraftingPage.md
@@ -1,0 +1,37 @@
+# CraftingPage
+
+Route: `/crafting` — `requiresAuth: false`.
+
+## Purpose
+Crafting mastery tracker. Shows per-hero progress across categories, subcategories, and item specializations. Includes a price calculator and a full item progress table.
+
+## Layout sections (top to bottom)
+1. **Hero banner** — title + Refresh + "Додати крафт" (admin) buttons
+2. **Filters row** — hero selector, "show uncrafted" toggle, highest discount chip
+3. **Summary metric cards** — total crafted, best discount, capped categories/subcategories/specializations
+4. **Progress panel** (left 7/12) — category progress bars + subcategory progress bars
+5. **Right panel** (5/12) — top crafted items list + craft price calculator
+6. **Item table** — expansion panel with full crafted-item breakdown per hero (collapsible)
+7. **Craft dialog** (admin) — `CraftActionForm` for logging a new craft action
+
+## Data loading
+`loadData()` fetches via `loadHeroesForCrafting()` and `loadCraftItems()` from `craftingService`. No real-time listener — manual refresh only.
+
+## Discount system
+Three tiers of discount, capped at 25% total:
+- Category discount (from `categoryProgress`)
+- Subcategory discount (from `subcategoryProgress`)
+- Specialization discount (per-item mastery)
+
+`recalculateHeroCrafting()` normalizes the hero's crafting state. `getItemDiscountBreakdown()` returns the full breakdown. `calculateFutureCraftPrice()` powers the calculator.
+
+## Calculator
+Inputs: item slug + quantity. Output: component price, each discount tier, discounted unit price, final total. Reads from `normalizedCrafting` of the selected hero.
+
+## Admin craft dialog
+`CraftActionForm` receives `heroes`, `items`, and `defaultHeroId`. After save, calls `onCraftSaved()` which closes dialog and reloads data.
+
+## Stores & services
+- `useUserStore` — `isAdmin`
+- `craftingService.js` — `loadCraftItems()`, `loadHeroesForCrafting()`, `getEmptyCraftingState()`
+- `src/utils/crafting/craftingCalculations.js` — all discount/progress calculations

--- a/src/views/DonationGoalsPage.md
+++ b/src/views/DonationGoalsPage.md
@@ -1,0 +1,24 @@
+# DonationGoalsPage
+
+Route: `/donations` — `requiresAuth: false`.
+
+## Purpose
+Displays community fundraising goals as cards. Any logged-in user can create a new goal. Clicking a card opens the donors summary dialog.
+
+## Sorting order
+1. Incomplete goals before complete (complete = `currentAmount === targetAmount`)
+2. Treasury goals (`treasury: true`) before non-treasury
+3. Newest first by `createdAt`
+
+## Components
+- `DonationGoalCard` — single goal card with progress bar; receives `goal`, `isAdmin`, `isLoggedIn`, `nickname`
+- `DonationsSummaryDialog` — shows donor breakdown for selected goal
+- `DonationGoalCreateDialog` — create form, pre-filled with `createdBy: nickname`
+
+## Auth visibility
+- **Create button** visible to any logged-in user (`isLoggedIn`)
+- `isAdmin` passed to cards for admin-only controls within the card
+
+## Stores
+- `useDonationGoalStore` — `subscribeToGoals()` / `stop()`, `goals`
+- `useUserStore` — `isAdmin`, `isLoggedIn`, `nickname`

--- a/src/views/GuildsPage.md
+++ b/src/views/GuildsPage.md
@@ -1,0 +1,30 @@
+# GuildsPage
+
+Route: `/guilds` — `requiresAuth: false`.
+
+## Purpose
+Guild management page. Shows guild cards with balance. Users can deposit funds; leaders and admins can withdraw. Admins can create/edit guilds and view full logs.
+
+## Visibility rules
+- Admin: sees all guilds
+- Leader: sees guilds where `user.canAccessGuild(guild.id)` is true, plus `visibleToAll` guilds
+- Regular user: sees only `visibleToAll` guilds
+
+## Dialogs
+Three separate dialogs on the same page:
+
+### Create/Edit guild dialog (`showGuildDialog`)
+Fields: name, shortName, leader, visibleToAll (checkbox), withdrawUsername, withdrawPassword, treasure (initial balance).
+
+### Transaction dialog (`showTxDialog`)
+Modes: `deposit` or `withdraw`. Password field shown for non-admin withdrawals. Withdraw access: admin always allowed; leader if `nickname === guild.withdrawUsername && password === guild.withdrawPassword`.
+
+### Logs dialog (`showLogsDialog`)
+Ledger table: when, who, type (deposit/withdraw), amount, comment, balance after. Available to admins and users with `canAccessGuild`. "Оновити" button reloads logs on demand.
+
+## Guild card layout
+CSS Grid: crest (col 1, rows 1-2), info (col 2, row 1), balance (col 3, rows 1-2), actions (col 1-3, row 3), log-hint (col 1-3, row 4). Negative balance triggers red border and `var(--wi-danger)` amount color.
+
+## Stores
+- `useGuildStore` — `subscribeGuilds()` / `unsubscribeGuilds()`, `guilds`, `addGuild()`, `updateGuild()`, `deposit()`, `withdraw()`, `getGuildLogs(guildId)`
+- `useUserStore` — `isAdmin`, `isLoggedIn`, `nickname`, `canAccessGuild(guildId)`

--- a/src/views/HomeView.md
+++ b/src/views/HomeView.md
@@ -1,0 +1,11 @@
+# HomeView
+
+Route: none (not currently registered in router).
+
+## Status
+Stub — contains only `<div>Home Page</div>`. Not linked from the navbar or any route. Reserved for a future landing/dashboard page.
+
+## If expanding this page
+- Add a route entry in `router/index.js`
+- Follow the pirate design system (see CLAUDE.md for design tokens)
+- Add a companion section to the Navbar if it should be globally accessible

--- a/src/views/IslandInfoPage.md
+++ b/src/views/IslandInfoPage.md
@@ -1,0 +1,27 @@
+# IslandInfoPage
+
+Route: `/islands/:islandId` (exact, child of IslandsPage).
+
+## Purpose
+Displays and edits core island parameters. Non-admins see read-only values; admins get inline text fields with a save button.
+
+## Editable fields
+| Field | Type | Notes |
+|-------|------|-------|
+| name | string | Island display name |
+| population | number | Total population count |
+| characters | number | Number of player characters |
+| buildingDiscount | number (%) | Discount applied to building costs |
+| repairDiscount | number (%) | Discount applied to ship repair costs |
+
+## Stores & data
+- `useIslandStore` — `subscribe()` / `stop()`, `updateIsland(payload)`
+- `useUserStore` — `isAdmin` gate
+
+## Admin behavior
+- All rows render `v-text-field` instead of plain `<span>` when `isAdmin`
+- Save triggers `islandStore.updateIsland()` with the full form payload
+- Saving state shown via `loading` prop on the save button
+
+## UI pattern
+"Captain's log" card: dark gradient background, alternating row tint, label-value rows. Discount values styled gold with `wi-number` font.

--- a/src/views/IslandsPage.md
+++ b/src/views/IslandsPage.md
@@ -1,0 +1,30 @@
+# IslandsPage
+
+Route: `/islands/:islandId` — parent shell, `requiresAuth: false`.
+
+## Purpose
+Layout shell for island-scoped pages. Renders the plank-tab navigation bar and a `<RouterView />` for the active child page. Does **not** render island content itself — each child page is responsible for its own content.
+
+## Child routes (tabs)
+| Tab label | Route | Component |
+|-----------|-------|-----------|
+| Інфо | `/islands/:islandId` | `IslandInfoPage` |
+| Будівлі | `/islands/:islandId/buildings` | `BuildingsPage` |
+| Населення | `/islands/:islandId/population` | `PopulationPage` |
+| Скарбниця | `/islands/:islandId/treasury` | `TreasuryPage` |
+| Мануфактури | `/islands/:islandId/manufactures` | `ManufacturesPage` |
+
+See each child page's `.md` for details.
+
+## Plank-tab pattern
+Tabs are `RouterLink`s styled as `.plank-tab`. Active tab uses `isExactActive` — only the exact route match activates, so `/islands/Камінь` and `/islands/Камінь/buildings` are independent.
+
+## Stores subscribed here
+- `islandStore.subscribe()` / `.stop()`
+- `buildingStore.subscribe()` / `.stop()`
+- `donationGoalStore.subscribeToGoals()` / `.stop()`
+
+These are mounted/unmounted at the shell level so child pages don't need to re-subscribe for island and building data.
+
+## Island name
+Currently hardcoded to `'Камінь'`. The `:islandId` param is not dynamically used yet — the tabs are built from the hardcoded string.

--- a/src/views/LoginView.md
+++ b/src/views/LoginView.md
@@ -1,0 +1,34 @@
+# LoginView
+
+Route: `/` — public, no auth guard.
+
+## Purpose
+Entry point for the app. Authenticates the user and stores identity in `userStore`. After login, redirects to `/ships`.
+
+## Auth flows
+- **Admin**: nickname `admin` + password verified via `verifyAdminPassword()` → `userStore.login(nickname, true)`
+- **Guild leader**: nickname checked via `isLeaderNickname()` (debounced watcher); if leader, password field appears; access granted via `getLeaderGuildAccess()` which returns `accessibleGuildIds`
+- **Regular user**: any nickname, no password required
+
+## Key behaviors
+- Password field only appears when nickname is `admin` or `requireLeaderPassword` is true
+- Leader check fires on each nickname change using an incrementing integer token (`checkToken`) — stale async responses are discarded by comparing the token after `await`
+- Regular users: **any non-empty nickname is accepted** — no server-side validation that the nickname exists
+- Redirect target after login is hardcoded to `/ships` for all user types
+- Errors use `mdi-skull-crossbones` icon per pirate theme
+
+## Session persistence
+`userStore` is plain in-memory Pinia — **no persistence across page refreshes**. This is why most routes have `requiresAuth: false`: there is no server session to verify, only client-side state. A hard refresh always returns the user to the login screen.
+
+## `accessibleGuildIds` downstream effect
+`getLeaderGuildAccess()` returns `accessibleGuildIds` which is stored as `userStore.leaderGuildAccessIds`. This powers `userStore.canAccessGuild(guildId)`, which gates guild withdrawal and log viewing on `GuildsPage`. It is set only at login time and cleared on logout.
+
+## Logout
+`userStore.logout()` clears `nickname`, `isAdmin`, and `leaderGuildAccessIds`. It is called from `Navbar.vue` — not from this page.
+
+## Stores & services
+- `useUserStore` — `login(nickname, isAdmin, accessibleGuildIds?)`
+- `authService.js` — `isLeaderNickname`, `verifyAdminPassword`, `getLeaderGuildAccess`
+
+## UI
+Animated wave sea background + scroll card. No Vuetify standard layout — fully custom CSS with pirate design tokens (`--wi-gold`, `--wi-font-heading`).

--- a/src/views/MageGuildPage.md
+++ b/src/views/MageGuildPage.md
@@ -1,0 +1,56 @@
+# MageGuildPage
+
+Route: `/mage-guild` — `requiresAuth: false`.
+
+## Purpose
+Shows magical service requests generated per cycle. Active cycle requests are shown as spell cards. Admins can mark requests as fulfilled. Previous cycle history shown as collapsible expansion panels (admin only).
+
+## Data model
+Requests are stored per-document, one document per cycle. Each document has a `requests` array of spell requests. The `store.latestRequestDocument` is the active cycle; `store.productionDocuments.slice(1)` is history.
+
+## Spell cards
+Color-coded by spell level (`SPELL_LEVEL_COLORS`, levels 0-9). Left border accent uses `--spell-color` CSS variable. Fulfilled cards are `opacity: 0.65`.
+
+Each card shows: level badge (tier icon + level number), spell name, status badge, downtime days, compensation amount, fulfilled-by hero name, Telegram post link.
+
+## Fulfillment dialog (admin only)
+Opens from a spell card's "Виконано" button. Fields: hero selector, Telegram post URL. Calls `store.markFulfilled()` with document ID, request ID, heroId, telegramPostUrl, actorName.
+
+`fulfillmentForms` is a reactive map keyed by `{documentId}:{requestId}` to persist partial form state across dialog opens.
+
+## Auto-generation
+On mount and when `islandStore.currentId` changes, `ensureCurrentCycleRequests()` is called. This creates the current cycle's request document if it doesn't exist yet, based on island population.
+
+## Business rules
+
+### Request count
+- `requestsMin = ceil(population / 100)`
+- `requestsMax = requestsMin × 3`
+- Actual count = random integer between min and max
+
+### Spell selection
+Spell level is picked by weighted random using `chance` values from the `mage-guild-configs/spell-request-prices` Firestore document (`spellTypes[level].chance`). Within the selected level, spell tier is also picked by weighted random (`spellTypes[level][tier].chance`). A random spell is then drawn from the matching pool.
+
+### Per-request values
+- `downtimeDays` = random integer between `tierConfig.downtimeMin` and `tierConfig.downtimeMax`
+- `compensation` = `spell.currentPrice + spell.materialComponentPrice`
+
+### Card sort order
+Unfulfilled requests first → highest compensation → alphabetical by spell name.
+
+### Price evolution (after cycle end)
+`settlePreviousSpellRequests()` (called by `cycleService` when a new cycle starts) adjusts each spell's `currentPrice`:
+- **Fulfilled** → price decreases by `priceConfig.delta` factor
+- **Unfulfilled** → price increases by `priceConfig.delta` factor
+- Price is clamped between `priceConfig.min` and `priceConfig.max`
+
+This means popular spells get cheaper over time and neglected ones get more expensive.
+
+### Fulfillment write
+Firestore transaction: reads the `spell-requests` document and the hero document, updates the matching request in the `requests` array in-place (sets `fulfilled`, `fulfilledByHeroId`, `fulfilledByHeroName`, `telegramPostUrl`), then writes back the full array.
+
+## Stores
+- `useMageGuildStore` — `startListening()` / `stopListening()`, `latestRequestDocument`, `productionDocuments`, `heroes`, `openCount`, `fulfilledCount`, `markFulfilled()`, `ensureCurrentCycleRequests()`
+- `useUserStore` — `isAdmin`, `nickname`
+- `usePopulationStore` — `totalPopulation`
+- `useIslandStore` — `currentId`

--- a/src/views/ManufacturesPage.md
+++ b/src/views/ManufacturesPage.md
@@ -1,0 +1,32 @@
+# ManufacturesPage
+
+Route: `/islands/:islandId/manufactures` (child of IslandsPage).
+
+## Purpose
+Lists manufactures linked to the island. Admins can add new ones or edit existing ones via a dialog.
+
+## Data loading
+Manufactures are stored as an array of IDs in `island.manufactures`. The page loads them directly from Firestore `manufactures` collection (chunked in batches of 10). Results are sorted to preserve the original order from the island document. No Pinia store — direct Firestore access.
+
+## Income destination
+Each manufacture has `incomeDestination`:
+- `'treasury'` — income goes to island treasury
+- `'guild:{guildId}'` — income goes to a specific guild
+
+Display label resolved from `guildStore.guilds`. Icon: `mdi-anchor` for treasury, `mdi-sword-cross` for guild.
+
+## Add/Edit dialog (admin only)
+Single dialog handles both modes (`dialogMode: 'add' | 'edit'`).
+
+**Add**: creates a new document in `manufactures` collection, then `arrayUnion`s its ID into `island.manufactures`.  
+**Edit**: updates the existing document in place; updates local `manufactures.value` array optimistically.
+
+Form fields: name (required), description, income (decimal, step 0.01), incomeDestination (select).
+
+## Stores
+- `useIslandStore` — `data.manufactures`, `data.id`
+- `useUserStore` — `isAdmin`
+- `useGuildStore` — `guilds` (for destination options)
+
+## Watcher
+`island.manufactures` change → `loadManufactures(ids)` re-runs.

--- a/src/views/PoliticsPage.md
+++ b/src/views/PoliticsPage.md
@@ -1,0 +1,37 @@
+# PoliticsPage
+
+> ⚠️ **Status: stale and redundant.** This page is not linked from the Navbar and is effectively hidden. It is not actively maintained. Avoid adding features here without first confirming the page is being revived.
+
+Route: `/politics` — `requiresAuth: false`.
+
+## Purpose
+Political proposals and interest group vote distribution. Non-admins see a read-only card view of current proposals with vote progress. Admins can CRUD proposals, toggle actuality, and edit the interest matrix.
+
+## Sections
+
+### Proposals (user view)
+Cards with title, summary, vote progress bar. Only `actual: true` proposals shown. Vote support = `proposalVotes[p.id] / TOTAL_VOTES * 100%`.
+
+### Proposals (admin view)
+Table with all proposals (including non-actual). Actions: toggle `actual` flag, delete. Delete also cleans up all related `interests` documents.
+
+### Add proposal form (admin only)
+Inline form below the table. Fields: title, summary. Saves with `actual: true` and `serverTimestamp()`.
+
+### Interest matrix (always visible)
+Sticky-header, sticky-first-column table. Rows = population groups, columns = proposals. Each cell has a number input for `people` count (disabled for non-admins). Vote distribution is calculated client-side.
+
+## Vote algorithm
+Total votes: `TOTAL_VOTES = 10` (with 1 decimal precision).  
+Group votes allocated proportionally by group `count` using `apportionFixed()` from `@/utils/votes`.  
+Per-proposal votes: each group's quota × (interested people / group population), distributed across proposals by `apportionFixed()`. Undecided population = group votes not assigned anywhere.
+
+## State
+- `proposals` — real-time Firestore listener (filtered by `actual` for non-admins)
+- `groups` — from `useInterestGroupStore` (real-time)
+- `interests` — real-time Firestore listener on `interests` collection, keyed as `{groupId}_{proposalId}`
+
+## Key computed values
+- `groupVotes` — each group's share of TOTAL_VOTES
+- `proposalVotes` — total votes per proposal across all groups
+- `groupUndecided` — how many people in each group have no stated preference

--- a/src/views/PopulationPage.md
+++ b/src/views/PopulationPage.md
@@ -1,0 +1,35 @@
+# PopulationPage
+
+Route: `/islands/:islandId/population` (child of IslandsPage).
+
+## Purpose
+Displays population groups as image cards with stats. Includes a pie chart summary. Admins can click any card to open an edit dialog where all group counts can be adjusted simultaneously.
+
+## Layout
+Two-column flex layout:
+- **Cards column** (`flex: 1 1 520px`) — `v-row` of group cards, one per population group
+- **Chart column** (`flex: 0 1 320px`) — pie chart with total/income summary
+
+## Population group cards
+Each card shows:
+- Background image from `g.imageUrl`
+- Hover overlay with description text
+- Stats: percentage, count (осіб), income per person
+- Name badge at bottom
+- "Редагувати" hint on hover (admin only)
+
+Color palette: 8 pirate-themed colors, cycled by index.
+
+## Edit dialog (admin only)
+Opens when admin clicks any card. Shows all groups at once with slider + number input per group. Constraints:
+- Sum of all groups must not exceed `totalPopulation` (from `islandStore`)
+- Slider ceiling auto-expands to `max(totalPopulation, maxGroupValue, 100)`
+- `overLimit` computed blocks save button
+
+## Stores
+- `usePopulationStore` — `startListening(islandId)` / `stopListening()`, `groupsAugmented`, `totalPopulation`, `populationIncomeTotal`, `setGroupCount(id, count)`
+- `useIslandStore` — `currentId` for listener
+- `useUserStore` — `isAdmin`
+
+## Chart
+`vue-chartjs` `Pie` component with `chart.js`. Legend at bottom, tooltip shows name + % + count + income.

--- a/src/views/ReligionPage.md
+++ b/src/views/ReligionPage.md
@@ -1,0 +1,30 @@
+# ReligionPage
+
+Route: `/religion` — `requiresAuth: false`.
+
+## Purpose
+Shows religion distribution, faith stats, and clergy abilities for the island. Has 4 view modes toggled via `v-btn-toggle`. See sub-files for each mode.
+
+## View modes
+| Value | Label | Component/content | Sub-file |
+|-------|-------|-------------------|----------|
+| `diagram` | Діаграма | `ReligionDistributionDiagram` | [DiagramView.md](ReligionPage/DiagramView.md) |
+| `table` | Таблиця | `ReligionDistributionTable` | [TableView.md](ReligionPage/TableView.md) |
+| `abilities` | Здібності | `ReligionAbilitiesTable` | [AbilitiesView.md](ReligionPage/AbilitiesView.md) |
+| `celestial` | Небожитель | `ReligionModals` | [CelestialView.md](ReligionPage/CelestialView.md) |
+
+Default view: `diagram`.
+
+## Stores & services
+- `useReligionStore` (or direct Firestore) — religion records, clergy, faith distribution
+- `usePopulationStore` — total island population for percentage calculations
+- `useIslandStore` — current island context
+
+## UI shell
+Single card with a `v-btn-toggle` in the header. The toggle label text is hidden on small screens (`.toggle-label` has responsive display). Active button highlighted with `color="primary"`.
+
+## Components imported
+- `ReligionDistributionDiagram`
+- `ReligionDistributionTable`
+- `ReligionAbilitiesTable`
+- `ReligionModals`

--- a/src/views/ReligionPage/AbilitiesView.md
+++ b/src/views/ReligionPage/AbilitiesView.md
@@ -1,0 +1,10 @@
+# ReligionPage — Здібності view
+
+Component: `ReligionAbilitiesTable` (`src/components/ReligionAbilitiesTable.vue`)
+
+## Purpose
+Displays the divine abilities/boons unlocked per religion, gated by faith thresholds. Shows each religion's available abilities and which are currently active based on current faith level.
+
+## Notes
+- Rendered when `viewMode === 'abilities'`
+- Read-only for all users (abilities are system-defined, not user-editable)

--- a/src/views/ReligionPage/CelestialView.md
+++ b/src/views/ReligionPage/CelestialView.md
@@ -1,0 +1,10 @@
+# ReligionPage — Небожитель view
+
+Component: `ReligionModals` (`src/components/ReligionModals.vue`)
+
+## Purpose
+Celestial/divine entity section. Shows information about a religion's patron deity or celestial being, and any associated modals/interactions for faith-related mechanics.
+
+## Notes
+- Rendered when `viewMode === 'celestial'`
+- Check `ReligionModals.vue` for the exact features — name suggests modal-driven interactions

--- a/src/views/ReligionPage/DiagramView.md
+++ b/src/views/ReligionPage/DiagramView.md
@@ -1,0 +1,14 @@
+# ReligionPage — Діаграма view
+
+Component: `ReligionDistributionDiagram` (`src/components/ReligionDistributionDiagram.vue`)
+
+## Purpose
+Donut/pie chart visualizing how the island's population is distributed across religions (as % of total followers and % of total population).
+
+## Data expected from parent
+- Religion records with follower counts
+- Total island population (from `populationStore`)
+
+## Notes
+- Default view when the page loads (`viewMode` starts as `'diagram'`)
+- Uses `chart.js` via `vue-chartjs`

--- a/src/views/ReligionPage/TableView.md
+++ b/src/views/ReligionPage/TableView.md
@@ -1,0 +1,13 @@
+# ReligionPage — Таблиця view
+
+Component: `ReligionDistributionTable` (`src/components/ReligionDistributionTable.vue`)
+
+## Purpose
+Tabular breakdown of religion data. Shows each religion's name, hero clergy, faith points, faith max, and follower counts with percentage.
+
+## Admin behavior
+Admins can edit faith values and follower counts inline or via dialog (check the component for exact pattern).
+
+## Notes
+- Rendered when `viewMode === 'table'`
+- Receives the same religion records as the diagram view

--- a/src/views/ShipsView.md
+++ b/src/views/ShipsView.md
@@ -1,0 +1,24 @@
+# ShipsView
+
+Route: `/ships` — `requiresAuth: false`.
+
+## Purpose
+Fleet management page. Displays all ships as cards. Admins can commission new ships or edit existing ones via `ShipEditor` dialog.
+
+## Components
+- `ShipCard` — displays a single ship's stats, emits `edit` event
+- `ShipEditor` (imported as `ShipDetailsDialog`) — form dialog for create/edit
+
+## Sorting
+- **Admin**: all ships sorted by visibility first (visible before hidden), then by `maxHP` descending
+- **Non-admin**: only ships with `visibility: true`, sorted by `maxHP` descending
+
+## New ship defaults
+When commissionning a new ship, a full zero-state object is constructed including ammunition types: `cannonballs`, `chain`, `grapeshot`, `smokeBombs`, `bolt`, `flamingBolt`, `catapultStone`, `salamanderFuel`, `dragonHeadFuel`.
+
+## Stores
+- `useShipStore` — `subscribeToShips()`, `ships`, `saveShip(updatedShip)`
+- `useUserStore` — `isAdmin`
+
+## Save flow
+`saveShip()` in the page calls `shipStore.saveShip(updatedShip)` then closes the dialog. The store handles Firestore write.

--- a/src/views/TravelView.md
+++ b/src/views/TravelView.md
@@ -1,0 +1,23 @@
+# TravelView
+
+Route: `/travel` — `requiresAuth: false`.
+
+## Purpose
+Container for travel-related calculators. Uses `v-tabs` + `v-window` to switch between two independent calculator tools.
+
+## Tabs
+| Tab value | Label | Component | Sub-file |
+|-----------|-------|-----------|----------|
+| `ships` | Кораблі | `ShipCalculator` | [TravelView/ShipsTab.md](TravelView/ShipsTab.md) |
+| `couriers` | Кур'єри | `CourierCalculator` | [TravelView/CouriersTab.md](TravelView/CouriersTab.md) |
+
+Default active tab: `ships`.
+
+## Tab styling
+`.travel-tabs` deep-styles `v-tab` with `wi-font-heading`, uppercase, gold color for selected, gold slider. No pirate card shell — uses standard Vuetify `v-tabs` on a clean container.
+
+## Hero banner
+Decorative banner with a slowly rotating `mdi-ship-wheel` watermark (60s CSS spin), title, and subtitle. No interactive elements.
+
+## State
+`activeTab` ref (`'ships'` | `'couriers'`) — only local state, no store involvement at the page level.

--- a/src/views/TravelView/CouriersTab.md
+++ b/src/views/TravelView/CouriersTab.md
@@ -1,0 +1,11 @@
+# TravelView — Кур'єри tab
+
+Component: `CourierCalculator` (`src/components/CourierCalculator.vue`)
+
+## Purpose
+Calculates courier (messenger bird) delivery time and cost between locations.
+
+## Notes
+- Self-contained component — no Pinia store, no Firestore reads
+- All logic is client-side calculation
+- Rendered inside `v-window-item value="couriers"` in TravelView

--- a/src/views/TravelView/ShipsTab.md
+++ b/src/views/TravelView/ShipsTab.md
@@ -1,0 +1,15 @@
+# TravelView — Кораблі tab
+
+Component: `ShipCalculator` (`src/components/ShipCalculator.vue`)
+
+## Purpose
+Calculates ship travel costs, journey duration, and hazard checks for a sea route between two points.
+
+## Key inputs/outputs (read the component for exact fields)
+Inputs typically include: ship type/speed, distance, crew modifiers.  
+Output: travel time, cost, risk level.
+
+## Notes
+- Self-contained component — no Pinia store, no Firestore reads
+- All logic is client-side calculation
+- Rendered inside `v-window-item value="ships"` in TravelView

--- a/src/views/TreasuryPage.md
+++ b/src/views/TreasuryPage.md
@@ -1,0 +1,26 @@
+# TreasuryPage
+
+Route: `/islands/:islandId/treasury` (child of IslandsPage).
+
+## Purpose
+Displays island treasury overview: total income/outcome summary, chest card, and transaction history. Composed entirely from sub-components — the page itself is a thin orchestration layer.
+
+## Components
+- `TreasuryChestCard` — chest balance and management UI
+- `TreasuryTransactions` — scrollable transaction ledger
+
+## Income/Outcome calculation
+The page aggregates income from two sources:
+1. **Manufactures** — loaded via direct Firestore query on `island.manufactures` IDs (chunked in batches of 10 due to Firestore `in` limit). Only manufactures with `incomeDestination === 'treasury'` are counted.
+2. **Population** — from `populationStore.populationIncomeTotal`. Positive = income, negative = outcome.
+
+`totalIncome` and `totalOutcome` are displayed in the header bar (green/red).
+
+## Stores & services
+- `useIslandStore` — `data.manufactures` (array of manufacture IDs)
+- `usePopulationStore` — `startListening(islandId)` / `stopListening()`, `populationIncomeTotal`
+- Direct Firestore reads from `manufactures` collection (not via a store)
+
+## Watchers
+- `island.manufactures` change → reload manufacture totals
+- `islandStore.currentId` change → restart population listener


### PR DESCRIPTION
## Summary

- Expanded `CLAUDE.md` with design system token table, typography classes, shared utilities/constants, Firestore access patterns, admin gate and dialog UI patterns, image asset locations, testing guidance, a full page documentation index, and a 6-step guide for creating new pages
- Added 27 companion `.md` files co-located with Vue views in `src/views/` — one per page, covering route, purpose, sections, stores, business rules, and admin/user behavior differences
- Complex pages with tabs or major sections have sub-directories (`ReligionPage/`, `TravelView/`, `AdminView/`) with per-tab/per-section files

## Why

Previously there was no structured documentation for page-level behavior, business rules, or conventions. This makes it harder for Claude Code and contributors to understand intent without reading every Vue file. The hierarchical system (CLAUDE.md index → page .md → section .md) scales as the app grows and keeps docs close to the code they describe.

## Reviewer notes

- `PoliticsPage.md` includes a stale/hidden warning — the page is not linked from the Navbar and not actively maintained
- `MageGuildPage.md` documents the spell request business rules in detail (weighted random selection, price evolution, fulfillment transaction) since these are non-obvious from reading the code
- All `.md` files are documentation-only — no runtime code was changed

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub (token table, links to page .md files)
- [ ] Spot-check a few page .md links from CLAUDE.md resolve to the correct files
- [ ] Confirm no `.vue` files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)