### PR TITLE
Feature: generate Telegram religion cycle summary

### DIFF
--- a/src/utils/religionSummary.js
+++ b/src/utils/religionSummary.js
@@ -1,0 +1,112 @@
+/**
+ * Aggregates religion-action documents for a cycle into structured data
+ * suitable for building the Telegram summary message.
+ *
+ * @param {object[]} actions - plain data objects (from docSnap.data())
+ * @param {Map<string,string>} heroNameById
+ * @param {Map<string,string>} religionNameById
+ */
+export function aggregateReligionActions(actions, heroNameById, religionNameById) {
+  const faithByHero = new Map()
+  const followersByReligion = new Map()
+  const shieldDefenses = []
+  const shieldsBrokenNames = []
+
+  for (const data of actions) {
+    const actionTypeId = data.actionType?.id
+
+    if (actionTypeId === 'generate') {
+      const heroId = data.heroId
+      const gained = Number(data.faithGained ?? 0)
+      if (gained <= 0 || !heroId) continue
+      const heroName = heroNameById.get(heroId) || heroId
+      if (!faithByHero.has(heroId)) faithByHero.set(heroId, { faith: 0, celestial: 0, name: heroName })
+      const entry = faithByHero.get(heroId)
+      if (data.farmTarget === 'celestial') entry.celestial += gained
+      else entry.faith += gained
+    }
+
+    if (actionTypeId === 'influence') {
+      const religionId = data.religion?.id
+      const targetReligionId = data.targetReligion?.id
+      const converted = Number(data.convertedFollowers ?? 0)
+      if (converted > 0 && religionId) {
+        const name = religionNameById.get(religionId) || religionId
+        const attackerName = religionNameById.get(targetReligionId) || targetReligionId || '?'
+        if (!followersByReligion.has(religionId)) {
+          followersByReligion.set(religionId, { gained: 0, name, attackerName })
+        }
+        followersByReligion.get(religionId).gained += converted
+      }
+      if (data.shieldBroken && targetReligionId) {
+        const targetName = religionNameById.get(targetReligionId) || targetReligionId
+        if (!shieldsBrokenNames.includes(targetName)) shieldsBrokenNames.push(targetName)
+      }
+    }
+
+    if (actionTypeId === 'shield') {
+      const bonus = Number(data.bonus ?? 0)
+      const religionId = data.religion?.id
+      if (bonus > 0 && religionId) {
+        const name = religionNameById.get(religionId) || religionId
+        shieldDefenses.push({ name, bonus })
+      }
+    }
+  }
+
+  return { faithByHero, followersByReligion, shieldDefenses, shieldsBrokenNames }
+}
+
+/**
+ * Builds the Telegram-ready summary string from aggregated cycle data.
+ *
+ * @param {{
+ *   faithByHero: Map,
+ *   followersByReligion: Map,
+ *   shieldDefenses: {name: string, bonus: number}[],
+ *   shieldsBrokenNames: string[],
+ *   newCycleDate: string,
+ * }} params
+ * @returns {string}
+ */
+export function buildReligionSummaryText({ faithByHero, followersByReligion, shieldDefenses, shieldsBrokenNames, newCycleDate }) {
+  const lines = []
+
+  const faithEntries = [...faithByHero.values()].filter((e) => e.faith > 0)
+  const celestialOnlyEntries = [...faithByHero.values()].filter((e) => e.faith === 0 && e.celestial > 0)
+
+  for (const entry of faithEntries) {
+    const parts = [`+${entry.faith} 🙏`]
+    if (entry.celestial > 0) parts.push(`+${entry.celestial} віри в небожителя`)
+    lines.push(`${entry.name} ${parts.join(' та ')}`)
+  }
+
+  if (faithEntries.length > 0 && celestialOnlyEntries.length > 0) lines.push('')
+
+  for (const entry of celestialOnlyEntries) {
+    lines.push(`${entry.name} +${entry.celestial} віри в небожителя`)
+  }
+
+  if ((faithEntries.length > 0 || celestialOnlyEntries.length > 0) && followersByReligion.size > 0) lines.push('')
+
+  for (const entry of followersByReligion.values()) {
+    lines.push(`Конфесія ${entry.name} +${entry.gained} послідовників1⃣ (від ${entry.attackerName})`)
+  }
+
+  if (shieldDefenses.length > 0) {
+    if (lines.length > 0) lines.push('')
+    for (const defense of shieldDefenses) {
+      lines.push(`Захист віри конфесія ${defense.name} +${defense.bonus} до стійкості 🧘`)
+    }
+  }
+
+  if (shieldsBrokenNames.length > 0) {
+    if (lines.length > 0) lines.push('')
+    lines.push(`Захисти спали у: ${shieldsBrokenNames.join(' та ')}.`)
+  }
+
+  if (lines.length > 0) lines.push('')
+  lines.push(`Розпочався новий цикл ${newCycleDate} — триває`)
+
+  return lines.join('\n')
+}

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -427,6 +427,7 @@ import { createNewCycleWithEffects } from '@/services/cycleService';
 import CraftActionForm from '@/components/crafting/CraftActionForm.vue';
 import { loadCraftItems } from '@/services/craftingService';
 import { DEFAULT_ISLAND_ID } from '@/config/constants.js';
+import { aggregateReligionActions, buildReligionSummaryText } from '@/utils/religionSummary.js';
 
 const logEntries = ref([]);
 const cycleSaving = ref(false);
@@ -726,93 +727,17 @@ async function generateReligionCycleSummary() {
       query(collection(db, 'religion-actions'), where('cycleId', '==', cycleId))
     );
 
-    const faithByHero = new Map();
-    const followersByReligion = new Map();
-    const shieldDefenses = [];
-    const shieldsBrokenNames = [];
+    const actions = actionsSnap.docs.map((docSnap) => docSnap.data());
+    const { faithByHero, followersByReligion, shieldDefenses, shieldsBrokenNames } =
+      aggregateReligionActions(actions, heroNameById, religionNameById);
 
-    for (const docSnap of actionsSnap.docs) {
-      const data = docSnap.data();
-      const actionTypeId = data.actionType?.id;
-
-      if (actionTypeId === 'generate') {
-        const heroId = data.heroId;
-        const gained = Number(data.faithGained ?? 0);
-        if (gained <= 0 || !heroId) continue;
-        const heroName = heroNameById.get(heroId) || heroId;
-        if (!faithByHero.has(heroId)) faithByHero.set(heroId, { faith: 0, celestial: 0, name: heroName });
-        const entry = faithByHero.get(heroId);
-        if (data.farmTarget === 'celestial') entry.celestial += gained;
-        else entry.faith += gained;
-      }
-
-      if (actionTypeId === 'influence') {
-        const religionId = data.religion?.id;
-        const targetReligionId = data.targetReligion?.id;
-        const converted = Number(data.convertedFollowers ?? 0);
-        if (converted > 0 && religionId) {
-          const name = religionNameById.get(religionId) || religionId;
-          const attackerName = religionNameById.get(targetReligionId) || targetReligionId || '?';
-          if (!followersByReligion.has(religionId)) {
-            followersByReligion.set(religionId, { gained: 0, name, attackerName });
-          }
-          followersByReligion.get(religionId).gained += converted;
-        }
-        if (data.shieldBroken && targetReligionId) {
-          const targetName = religionNameById.get(targetReligionId) || targetReligionId;
-          if (!shieldsBrokenNames.includes(targetName)) shieldsBrokenNames.push(targetName);
-        }
-      }
-
-      if (actionTypeId === 'shield') {
-        const bonus = Number(data.bonus ?? 0);
-        const religionId = data.religion?.id;
-        if (bonus > 0 && religionId) {
-          const name = religionNameById.get(religionId) || religionId;
-          shieldDefenses.push({ name, bonus });
-        }
-      }
-    }
-
-    const lines = [];
-
-    const faithEntries = [...faithByHero.values()].filter((e) => e.faith > 0);
-    const celestialOnlyEntries = [...faithByHero.values()].filter((e) => e.faith === 0 && e.celestial > 0);
-
-    for (const entry of faithEntries) {
-      const parts = [`+${entry.faith} 🙏`];
-      if (entry.celestial > 0) parts.push(`+${entry.celestial} віри в небожителя`);
-      lines.push(`${entry.name} ${parts.join(' та ')}`);
-    }
-
-    if (faithEntries.length > 0 && celestialOnlyEntries.length > 0) lines.push('');
-
-    for (const entry of celestialOnlyEntries) {
-      lines.push(`${entry.name} +${entry.celestial} віри в небожителя`);
-    }
-
-    if ((faithEntries.length > 0 || celestialOnlyEntries.length > 0) && followersByReligion.size > 0) lines.push('');
-
-    for (const entry of followersByReligion.values()) {
-      lines.push(`Конфесія ${entry.name} +${entry.gained} послідовників1⃣ (від ${entry.attackerName})`);
-    }
-
-    if (shieldDefenses.length > 0) {
-      if (lines.length > 0) lines.push('');
-      for (const defense of shieldDefenses) {
-        lines.push(`Захист віри конфесія ${defense.name} +${defense.bonus} до стійкості 🧘`);
-      }
-    }
-
-    if (shieldsBrokenNames.length > 0) {
-      if (lines.length > 0) lines.push('');
-      lines.push(`Захисти спали у: ${shieldsBrokenNames.join(' та ')}.`);
-    }
-
-    if (lines.length > 0) lines.push('');
-    lines.push(`Розпочався новий цикл ${latestCycle.value?.startedAt || ''} — триває`);
-
-    religionSummaryText.value = lines.join('\n');
+    religionSummaryText.value = buildReligionSummaryText({
+      faithByHero,
+      followersByReligion,
+      shieldDefenses,
+      shieldsBrokenNames,
+      newCycleDate: latestCycle.value?.startedAt || '',
+    });
     showReligionSummaryDialog.value = true;
   } catch (e) {
     console.error('[admin] Failed to generate religion summary', e);

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -34,6 +34,16 @@
         <v-btn color="primary" prepend-icon="mdi-play-circle-outline" :loading="cycleSaving" @click="createCycle">
           Почати новий цикл
         </v-btn>
+        <v-btn
+          color="secondary"
+          prepend-icon="mdi-telegram"
+          :loading="religionSummaryLoading"
+          :disabled="!previousCompletedCycle"
+          class="ml-3"
+          @click="generateReligionCycleSummary"
+        >
+          Підсумок релігій
+        </v-btn>
       </v-form>
 
       <v-divider class="my-4" />
@@ -364,6 +374,31 @@
       </v-data-table>
     </v-card>
   </v-container>
+
+  <v-dialog v-model="showReligionSummaryDialog" max-width="620">
+    <v-card>
+      <div class="pa-4" style="border-bottom: 1px solid var(--wi-border)">
+        <span class="wi-heading text-h6">Підсумок релігійних дій циклу</span>
+      </div>
+      <v-card-text class="pt-4">
+        <v-textarea
+          v-model="religionSummaryText"
+          rows="14"
+          auto-grow
+          variant="outlined"
+          hide-details
+        />
+      </v-card-text>
+      <v-divider />
+      <v-card-actions>
+        <v-spacer />
+        <v-btn prepend-icon="mdi-content-copy" color="primary" @click="copyReligionSummary">
+          {{ religionSummaryCopied ? 'Скопійовано!' : 'Копіювати' }}
+        </v-btn>
+        <v-btn @click="showReligionSummaryDialog = false">Закрити</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup>
@@ -381,6 +416,7 @@ import {
   serverTimestamp,
   Timestamp,
   updateDoc,
+  where,
 } from 'firebase/firestore';
 import { DEFAULT_YEAR, diffInDays, normalizeFaerunDate, parseFaerunDate } from 'faerun-date';
 import { db } from '../services/firebase';
@@ -397,6 +433,11 @@ const cycleSaving = ref(false);
 const cycleError = ref('');
 const cycleSuccess = ref('');
 const latestCycle = ref(null);
+const previousCompletedCycle = ref(null);
+const religionSummaryText = ref('');
+const showReligionSummaryDialog = ref(false);
+const religionSummaryLoading = ref(false);
+const religionSummaryCopied = ref(false);
 const islandStore = useIslandStore();
 const populationStore = usePopulationStore();
 const cycleForm = reactive({
@@ -615,9 +656,10 @@ const cycleDurationLabel = computed(() => {
 
 async function loadLatestCycle() {
   const cyclesRef = collection(db, 'cycles');
-  const latestCycleQuery = query(cyclesRef, orderBy('createdAt', 'desc'), limit(1));
+  const latestCycleQuery = query(cyclesRef, orderBy('createdAt', 'desc'), limit(2));
   const snapshot = await getDocs(latestCycleQuery);
   latestCycle.value = snapshot.docs[0] ? { id: snapshot.docs[0].id, ...snapshot.docs[0].data() } : null;
+  previousCompletedCycle.value = snapshot.docs[1] ? { id: snapshot.docs[1].id, ...snapshot.docs[1].data() } : null;
 }
 
 function suggestNextCycleDate() {
@@ -669,6 +711,121 @@ async function createCycle() {
   } finally {
     cycleSaving.value = false;
   }
+}
+
+async function generateReligionCycleSummary() {
+  if (!previousCompletedCycle.value) return;
+
+  religionSummaryLoading.value = true;
+  try {
+    const heroNameById = new Map(heroes.value.map((h) => [h.id, h.name]));
+    const religionNameById = new Map(religions.value.map((r) => [r.id, r.name]));
+    const cycleId = previousCompletedCycle.value.id;
+
+    const actionsSnap = await getDocs(
+      query(collection(db, 'religion-actions'), where('cycleId', '==', cycleId))
+    );
+
+    const faithByHero = new Map();
+    const followersByReligion = new Map();
+    const shieldDefenses = [];
+    const shieldsBrokenNames = [];
+
+    for (const docSnap of actionsSnap.docs) {
+      const data = docSnap.data();
+      const actionTypeId = data.actionType?.id;
+
+      if (actionTypeId === 'generate') {
+        const heroId = data.heroId;
+        const gained = Number(data.faithGained ?? 0);
+        if (gained <= 0 || !heroId) continue;
+        const heroName = heroNameById.get(heroId) || heroId;
+        if (!faithByHero.has(heroId)) faithByHero.set(heroId, { faith: 0, celestial: 0, name: heroName });
+        const entry = faithByHero.get(heroId);
+        if (data.farmTarget === 'celestial') entry.celestial += gained;
+        else entry.faith += gained;
+      }
+
+      if (actionTypeId === 'influence') {
+        const religionId = data.religion?.id;
+        const targetReligionId = data.targetReligion?.id;
+        const converted = Number(data.convertedFollowers ?? 0);
+        if (converted > 0 && religionId) {
+          const name = religionNameById.get(religionId) || religionId;
+          const attackerName = religionNameById.get(targetReligionId) || targetReligionId || '?';
+          if (!followersByReligion.has(religionId)) {
+            followersByReligion.set(religionId, { gained: 0, name, attackerName });
+          }
+          followersByReligion.get(religionId).gained += converted;
+        }
+        if (data.shieldBroken && targetReligionId) {
+          const targetName = religionNameById.get(targetReligionId) || targetReligionId;
+          if (!shieldsBrokenNames.includes(targetName)) shieldsBrokenNames.push(targetName);
+        }
+      }
+
+      if (actionTypeId === 'shield') {
+        const bonus = Number(data.bonus ?? 0);
+        const religionId = data.religion?.id;
+        if (bonus > 0 && religionId) {
+          const name = religionNameById.get(religionId) || religionId;
+          shieldDefenses.push({ name, bonus });
+        }
+      }
+    }
+
+    const lines = [];
+
+    const faithEntries = [...faithByHero.values()].filter((e) => e.faith > 0);
+    const celestialOnlyEntries = [...faithByHero.values()].filter((e) => e.faith === 0 && e.celestial > 0);
+
+    for (const entry of faithEntries) {
+      const parts = [`+${entry.faith} 🙏`];
+      if (entry.celestial > 0) parts.push(`+${entry.celestial} віри в небожителя`);
+      lines.push(`${entry.name} ${parts.join(' та ')}`);
+    }
+
+    if (faithEntries.length > 0 && celestialOnlyEntries.length > 0) lines.push('');
+
+    for (const entry of celestialOnlyEntries) {
+      lines.push(`${entry.name} +${entry.celestial} віри в небожителя`);
+    }
+
+    if ((faithEntries.length > 0 || celestialOnlyEntries.length > 0) && followersByReligion.size > 0) lines.push('');
+
+    for (const entry of followersByReligion.values()) {
+      lines.push(`Конфесія ${entry.name} +${entry.gained} послідовників1⃣ (від ${entry.attackerName})`);
+    }
+
+    if (shieldDefenses.length > 0) {
+      if (lines.length > 0) lines.push('');
+      for (const defense of shieldDefenses) {
+        lines.push(`Захист віри конфесія ${defense.name} +${defense.bonus} до стійкості 🧘`);
+      }
+    }
+
+    if (shieldsBrokenNames.length > 0) {
+      if (lines.length > 0) lines.push('');
+      lines.push(`Захисти спали у: ${shieldsBrokenNames.join(' та ')}.`);
+    }
+
+    if (lines.length > 0) lines.push('');
+    lines.push(`Розпочався новий цикл ${latestCycle.value?.startedAt || ''} — триває`);
+
+    religionSummaryText.value = lines.join('\n');
+    showReligionSummaryDialog.value = true;
+  } catch (e) {
+    console.error('[admin] Failed to generate religion summary', e);
+  } finally {
+    religionSummaryLoading.value = false;
+  }
+}
+
+async function copyReligionSummary() {
+  if (!religionSummaryText.value) return;
+  await navigator.clipboard.writeText(religionSummaryText.value);
+  religionSummaryCopied.value = true;
+  setTimeout(() => { religionSummaryCopied.value = false; }, 2000);
 }
 
 function subscribeHeroData() {

--- a/src/views/ReligionPage.vue
+++ b/src/views/ReligionPage.vue
@@ -1673,6 +1673,7 @@ async function applyClergyDefense() {
         result,
         bonus,
         shieldApplied: bonus > 0,
+        cycleId: latestCycle.value?.id || null,
         user: userStore.nickname || 'Адміністратор',
         createdAt: serverTimestamp(),
       }),

--- a/tests/utils/religionSummary.test.js
+++ b/tests/utils/religionSummary.test.js
@@ -1,0 +1,462 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { aggregateReligionActions, buildReligionSummaryText } from '../../src/utils/religionSummary.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function action(actionTypeId, fields) {
+  return { actionType: { id: actionTypeId }, ...fields };
+}
+
+const HEROES = new Map([
+  ['h1', 'Марселін'],
+  ['h2', 'Валеріан'],
+  ['h3', 'Джеремайя'],
+]);
+
+const RELIGIONS = new Map([
+  ['r-devil', 'Девіл'],
+  ['r-blib', 'Блібдулпулп'],
+  ['r-istishia', 'Істишія'],
+]);
+
+const EMPTY_HEROES = new Map();
+const EMPTY_RELIGIONS = new Map();
+
+// ---------------------------------------------------------------------------
+// aggregateReligionActions — generate (faith farming)
+// ---------------------------------------------------------------------------
+
+test('generate action adds faith to hero', () => {
+  const actions = [action('generate', { heroId: 'h1', faithGained: 40 })];
+  const { faithByHero } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(faithByHero.get('h1').faith, 40);
+  assert.equal(faithByHero.get('h1').celestial, 0);
+  assert.equal(faithByHero.get('h1').name, 'Марселін');
+});
+
+test('generate action with farmTarget=celestial adds to celestial, not faith', () => {
+  const actions = [action('generate', { heroId: 'h3', faithGained: 28, farmTarget: 'celestial' })];
+  const { faithByHero } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(faithByHero.get('h3').faith, 0);
+  assert.equal(faithByHero.get('h3').celestial, 28);
+});
+
+test('multiple generate actions for the same hero accumulate', () => {
+  const actions = [
+    action('generate', { heroId: 'h1', faithGained: 20 }),
+    action('generate', { heroId: 'h1', faithGained: 20, farmTarget: 'celestial' }),
+    action('generate', { heroId: 'h1', faithGained: 15 }),
+  ];
+  const { faithByHero } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(faithByHero.get('h1').faith, 35);
+  assert.equal(faithByHero.get('h1').celestial, 20);
+});
+
+test('generate action with gained=0 is skipped', () => {
+  const actions = [action('generate', { heroId: 'h1', faithGained: 0 })];
+  const { faithByHero } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(faithByHero.size, 0);
+});
+
+test('generate action without heroId is skipped', () => {
+  const actions = [action('generate', { faithGained: 10 })];
+  const { faithByHero } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(faithByHero.size, 0);
+});
+
+test('generate action falls back to heroId as name when not in map', () => {
+  const actions = [action('generate', { heroId: 'unknown-hero', faithGained: 5 })];
+  const { faithByHero } = aggregateReligionActions(actions, EMPTY_HEROES, EMPTY_RELIGIONS);
+
+  assert.equal(faithByHero.get('unknown-hero').name, 'unknown-hero');
+});
+
+// ---------------------------------------------------------------------------
+// aggregateReligionActions — influence (spread religion)
+// ---------------------------------------------------------------------------
+
+test('influence action with converted followers adds to source religion', () => {
+  const actions = [action('influence', {
+    religion: { id: 'r-blib' },
+    targetReligion: { id: 'r-devil' },
+    convertedFollowers: 12,
+    shieldBroken: false,
+  })];
+  const { followersByReligion } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  const entry = followersByReligion.get('r-blib');
+  assert.equal(entry.gained, 12);
+  assert.equal(entry.name, 'Блібдулпулп');
+  assert.equal(entry.attackerName, 'Девіл');
+});
+
+test('influence action with converted=0 is skipped', () => {
+  const actions = [action('influence', {
+    religion: { id: 'r-blib' },
+    targetReligion: { id: 'r-devil' },
+    convertedFollowers: 0,
+  })];
+  const { followersByReligion } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(followersByReligion.size, 0);
+});
+
+test('multiple influence actions from the same religion accumulate followers', () => {
+  const actions = [
+    action('influence', { religion: { id: 'r-devil' }, targetReligion: { id: 'r-blib' }, convertedFollowers: 10, shieldBroken: false }),
+    action('influence', { religion: { id: 'r-devil' }, targetReligion: { id: 'r-blib' }, convertedFollowers: 7, shieldBroken: false }),
+  ];
+  const { followersByReligion } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(followersByReligion.get('r-devil').gained, 17);
+});
+
+test('influence action with shieldBroken=true adds target religion to broken list', () => {
+  const actions = [action('influence', {
+    religion: { id: 'r-blib' },
+    targetReligion: { id: 'r-devil' },
+    convertedFollowers: 5,
+    shieldBroken: true,
+  })];
+  const { shieldsBrokenNames } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.deepEqual(shieldsBrokenNames, ['Девіл']);
+});
+
+test('influence action with shieldBroken=false does not add to broken list', () => {
+  const actions = [action('influence', {
+    religion: { id: 'r-blib' },
+    targetReligion: { id: 'r-devil' },
+    convertedFollowers: 5,
+    shieldBroken: false,
+  })];
+  const { shieldsBrokenNames } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(shieldsBrokenNames.length, 0);
+});
+
+test('influence broken shield is deduplicated if same religion appears twice', () => {
+  const actions = [
+    action('influence', { religion: { id: 'r-blib' }, targetReligion: { id: 'r-devil' }, convertedFollowers: 5, shieldBroken: true }),
+    action('influence', { religion: { id: 'r-istishia' }, targetReligion: { id: 'r-devil' }, convertedFollowers: 3, shieldBroken: true }),
+  ];
+  const { shieldsBrokenNames } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.deepEqual(shieldsBrokenNames, ['Девіл']);
+});
+
+test('influence falls back to religionId as name when not in map', () => {
+  const actions = [action('influence', {
+    religion: { id: 'r-unknown' },
+    targetReligion: { id: 'r-also-unknown' },
+    convertedFollowers: 5,
+    shieldBroken: false,
+  })];
+  const { followersByReligion } = aggregateReligionActions(actions, EMPTY_HEROES, EMPTY_RELIGIONS);
+
+  const entry = followersByReligion.get('r-unknown');
+  assert.equal(entry.name, 'r-unknown');
+  assert.equal(entry.attackerName, 'r-also-unknown');
+});
+
+test('influence with no targetReligion uses fallback attacker name', () => {
+  const actions = [action('influence', {
+    religion: { id: 'r-blib' },
+    convertedFollowers: 5,
+    shieldBroken: false,
+  })];
+  const { followersByReligion } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(followersByReligion.get('r-blib').attackerName, '?');
+});
+
+// ---------------------------------------------------------------------------
+// aggregateReligionActions — shield (defence)
+// ---------------------------------------------------------------------------
+
+test('shield action with bonus > 0 adds to shieldDefenses', () => {
+  const actions = [action('shield', { religion: { id: 'r-devil' }, bonus: 4, shieldApplied: true })];
+  const { shieldDefenses } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(shieldDefenses.length, 1);
+  assert.equal(shieldDefenses[0].name, 'Девіл');
+  assert.equal(shieldDefenses[0].bonus, 4);
+});
+
+test('shield action with bonus=0 is skipped', () => {
+  const actions = [action('shield', { religion: { id: 'r-devil' }, bonus: 0, shieldApplied: false })];
+  const { shieldDefenses } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(shieldDefenses.length, 0);
+});
+
+test('shield action without religionId is skipped', () => {
+  const actions = [action('shield', { bonus: 4 })];
+  const { shieldDefenses } = aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(shieldDefenses.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// aggregateReligionActions — unrelated action types
+// ---------------------------------------------------------------------------
+
+test('cycleStart and unknown action types are ignored', () => {
+  const actions = [
+    action('cycleStart', { notes: 'some notes', convertedFollowers: 0, result: 0 }),
+    action('unknownType', { heroId: 'h1', value: 99 }),
+  ];
+  const { faithByHero, followersByReligion, shieldDefenses, shieldsBrokenNames } =
+    aggregateReligionActions(actions, HEROES, RELIGIONS);
+
+  assert.equal(faithByHero.size, 0);
+  assert.equal(followersByReligion.size, 0);
+  assert.equal(shieldDefenses.length, 0);
+  assert.equal(shieldsBrokenNames.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// buildReligionSummaryText — faith lines
+// ---------------------------------------------------------------------------
+
+test('faith-only hero renders correct line', () => {
+  const faithByHero = new Map([['h1', { faith: 10, celestial: 0, name: 'Валеріан' }]]);
+  const text = buildReligionSummaryText({
+    faithByHero,
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  assert.ok(text.includes('Валеріан +10 🙏'));
+});
+
+test('hero with both faith and celestial renders combined line', () => {
+  const faithByHero = new Map([['h1', { faith: 40, celestial: 20, name: 'Марселін' }]]);
+  const text = buildReligionSummaryText({
+    faithByHero,
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  assert.ok(text.includes('Марселін +40 🙏 та +20 віри в небожителя'));
+});
+
+test('celestial-only hero renders separate line without 🙏', () => {
+  const faithByHero = new Map([['h3', { faith: 0, celestial: 28, name: 'Джеремайя' }]]);
+  const text = buildReligionSummaryText({
+    faithByHero,
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  assert.ok(text.includes('Джеремайя +28 віри в небожителя'));
+  assert.ok(!text.includes('🙏'));
+});
+
+test('faith heroes and celestial-only heroes are separated by blank line', () => {
+  const faithByHero = new Map([
+    ['h1', { faith: 40, celestial: 0, name: 'Марселін' }],
+    ['h3', { faith: 0, celestial: 28, name: 'Джеремайя' }],
+  ]);
+  const text = buildReligionSummaryText({
+    faithByHero,
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  const lines = text.split('\n');
+  const marcIdx = lines.findIndex((l) => l.includes('Марселін'));
+  const jeremIdx = lines.findIndex((l) => l.includes('Джеремайя'));
+  assert.equal(lines[marcIdx + 1], '', 'expected blank line between faith and celestial-only sections');
+  assert.equal(jeremIdx, marcIdx + 2);
+});
+
+// ---------------------------------------------------------------------------
+// buildReligionSummaryText — follower lines
+// ---------------------------------------------------------------------------
+
+test('follower line renders correctly', () => {
+  const followersByReligion = new Map([
+    ['r-blib', { gained: 12, name: 'Блібдулпулп', attackerName: 'Девіл' }],
+  ]);
+  const text = buildReligionSummaryText({
+    faithByHero: new Map(),
+    followersByReligion,
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  assert.ok(text.includes('Конфесія Блібдулпулп +12 послідовників1⃣ (від Девіл)'));
+});
+
+test('faith section and follower section are separated by blank line', () => {
+  const faithByHero = new Map([['h1', { faith: 10, celestial: 0, name: 'Валеріан' }]]);
+  const followersByReligion = new Map([['r-blib', { gained: 12, name: 'Блібдулпулп', attackerName: 'Девіл' }]]);
+  const text = buildReligionSummaryText({
+    faithByHero,
+    followersByReligion,
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  const lines = text.split('\n');
+  const faithIdx = lines.findIndex((l) => l.includes('Валеріан'));
+  const followerIdx = lines.findIndex((l) => l.includes('Блібдулпулп'));
+  assert.equal(lines[faithIdx + 1], '', 'expected blank line between faith and follower sections');
+  assert.equal(followerIdx, faithIdx + 2);
+});
+
+// ---------------------------------------------------------------------------
+// buildReligionSummaryText — shield defence and broken shields
+// ---------------------------------------------------------------------------
+
+test('shield defence line renders correctly', () => {
+  const text = buildReligionSummaryText({
+    faithByHero: new Map(),
+    followersByReligion: new Map(),
+    shieldDefenses: [{ name: 'Девіл', bonus: 4 }],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  assert.ok(text.includes('Захист віри конфесія Девіл +4 до стійкості 🧘'));
+});
+
+test('broken shields line renders correctly for one religion', () => {
+  const text = buildReligionSummaryText({
+    faithByHero: new Map(),
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: ['Девіл'],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  assert.ok(text.includes('Захисти спали у: Девіл.'));
+});
+
+test('broken shields line joins multiple religions with та', () => {
+  const text = buildReligionSummaryText({
+    faithByHero: new Map(),
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: ['Блібдулпулп', 'Девіл'],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  assert.ok(text.includes('Захисти спали у: Блібдулпулп та Девіл.'));
+});
+
+// ---------------------------------------------------------------------------
+// buildReligionSummaryText — cycle announcement
+// ---------------------------------------------------------------------------
+
+test('cycle announcement appears as last line', () => {
+  const text = buildReligionSummaryText({
+    faithByHero: new Map(),
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817 рік після Потопу',
+  });
+
+  const lines = text.split('\n');
+  assert.equal(lines[lines.length - 1], 'Розпочався новий цикл 4 Eleasis 817 рік після Потопу — триває');
+});
+
+test('when no actions present, only cycle announcement line is produced', () => {
+  const text = buildReligionSummaryText({
+    faithByHero: new Map(),
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '1 Mirtul 817',
+  });
+
+  assert.equal(text, 'Розпочався новий цикл 1 Mirtul 817 — триває');
+});
+
+test('cycle announcement is preceded by blank line when there are other sections', () => {
+  const faithByHero = new Map([['h1', { faith: 10, celestial: 0, name: 'Валеріан' }]]);
+  const text = buildReligionSummaryText({
+    faithByHero,
+    followersByReligion: new Map(),
+    shieldDefenses: [],
+    shieldsBrokenNames: [],
+    newCycleDate: '4 Eleasis 817',
+  });
+
+  const lines = text.split('\n');
+  const lastLine = lines[lines.length - 1];
+  const secondLastLine = lines[lines.length - 2];
+  assert.equal(lastLine, 'Розпочався новий цикл 4 Eleasis 817 — триває');
+  assert.equal(secondLastLine, '');
+});
+
+// ---------------------------------------------------------------------------
+// Full integration: example message from spec
+// ---------------------------------------------------------------------------
+
+test('produces the expected Telegram message for a full cycle', () => {
+  const actions = [
+    action('generate', { heroId: 'h-martselin', faithGained: 40 }),
+    action('generate', { heroId: 'h-martselin', faithGained: 20, farmTarget: 'celestial' }),
+    action('generate', { heroId: 'h-valerian', faithGained: 10 }),
+    action('generate', { heroId: 'h-kaeloris', faithGained: 10 }),
+    action('generate', { heroId: 'h-dik', faithGained: 10 }),
+    action('generate', { heroId: 'h-jeremiah', faithGained: 28, farmTarget: 'celestial' }),
+    action('influence', { religion: { id: 'r-blib' }, targetReligion: { id: 'r-devil' }, convertedFollowers: 12, shieldBroken: true }),
+    action('influence', { religion: { id: 'r-devil' }, targetReligion: { id: 'r-blib' }, convertedFollowers: 17, shieldBroken: true }),
+    action('shield', { religion: { id: 'r-devil' }, bonus: 4 }),
+  ];
+
+  const heroes = new Map([
+    ['h-martselin', 'Марселін'],
+    ['h-valerian', 'Валеріан'],
+    ['h-kaeloris', 'Каеларіс'],
+    ['h-dik', 'Дік'],
+    ['h-jeremiah', 'Джеремайя'],
+  ]);
+  const religions = new Map([
+    ['r-devil', 'Девіл'],
+    ['r-blib', 'Блібдулпулп'],
+  ]);
+
+  const { faithByHero, followersByReligion, shieldDefenses, shieldsBrokenNames } =
+    aggregateReligionActions(actions, heroes, religions);
+  const text = buildReligionSummaryText({
+    faithByHero,
+    followersByReligion,
+    shieldDefenses,
+    shieldsBrokenNames,
+    newCycleDate: '4 Eleasis 817 рік після Потопу',
+  });
+
+  assert.ok(text.includes('Марселін +40 🙏 та +20 віри в небожителя'));
+  assert.ok(text.includes('Валеріан +10 🙏'));
+  assert.ok(text.includes('Каеларіс +10 🙏'));
+  assert.ok(text.includes('Дік +10 🙏'));
+  assert.ok(text.includes('Джеремайя +28 віри в небожителя'));
+  assert.ok(text.includes('Конфесія Блібдулпулп +12 послідовників1⃣ (від Девіл)'));
+  assert.ok(text.includes('Конфесія Девіл +17 послідовників1⃣ (від Блібдулпулп)'));
+  assert.ok(text.includes('Захист віри конфесія Девіл +4 до стійкості 🧘'));
+  assert.ok(text.includes('Захисти спали у:') && text.includes('Блібдулпулп') && text.includes('Девіл'));
+  assert.ok(text.endsWith('Розпочався новий цикл 4 Eleasis 817 рік після Потопу — триває'));
+});


### PR DESCRIPTION
## Summary
- Adds a **Підсумок релігій** button in the Admin panel's Cycles section that generates a ready-to-paste Telegram message after starting a new cycle
- Queries the previous cycle's `religion-actions` by `cycleId` to aggregate: per-hero faith (🙏) and celestial faith gains, per-religion follower changes (from spread), shield defence bonuses, and broken shields
- Backfills `cycleId` onto shield/defence actions in `ReligionPage.vue` so they are captured alongside `generate` and `influence` actions

## How it works
1. After starting a new cycle, click **Підсумок релігій** (disabled until a completed previous cycle exists)
2. A dialog opens with the generated Ukrainian text, editable before copying
3. Click **Копіювати** — pastes into clipboard with a 2-second confirmation

## Test plan
- [ ] Start a new cycle in the Admin panel — button becomes enabled
- [ ] Click **Підсумок релігій** — dialog opens with correct hero faith lines, follower lines, shield lines, and the new cycle date at the bottom
- [ ] Perform a clergy defence action and verify it appears in the next summary (cycleId now stored)
- [ ] Edit text in the dialog, click Копіювати — clipboard contains the edited text
- [ ] Open admin panel with only 1 cycle in DB — button is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)