### PR TITLE
feat: add Бюрократи faction with cycle tax-adjustment mechanics

### DIFF
--- a/src/services/cycleService.js
+++ b/src/services/cycleService.js
@@ -90,6 +90,50 @@ export async function loadManufacturesByIds(ids, {
   return results
 }
 
+function applyBureaucratEffects(populationEntries, rng) {
+  const bureaucratGroups = populationEntries.filter((e) => e.faction === 'bureaucrats')
+  const nonBureaucratGroups = populationEntries.filter((e) => e.faction !== 'bureaucrats')
+
+  if (!bureaucratGroups.length) return { entries: populationEntries, bureaucratStats: null }
+
+  const bureaucratCount = bureaucratGroups.reduce((s, g) => s + g.count, 0)
+  const totalNonBureaucratPop = nonBureaucratGroups.reduce((s, g) => s + g.count, 0)
+  const bureaucratCapacity = bureaucratCount * 100
+  const coveredCount = Math.min(bureaucratCapacity, totalNonBureaucratPop)
+  const isFull = totalNonBureaucratPop > 0 && coveredCount >= totalNonBureaucratPop
+  const coveredFraction = totalNonBureaucratPop > 0 ? Math.min(1, bureaucratCapacity / totalNonBureaucratPop) : 0
+
+  const adjustedNonBureaucrats = nonBureaucratGroups.map((group) => {
+    const groupCovered = Math.round(group.count * coveredFraction)
+    const groupUncovered = group.count - groupCovered
+    const bonusPerPerson = Math.max(Math.abs(group.incomePerPerson) * 0.20, 0.01)
+
+    let groupBonus = 0
+    if (isFull) {
+      for (let i = 0; i < groupCovered; i++) {
+        if (rng() < 0.20) groupBonus += bonusPerPerson
+      }
+    }
+
+    let groupPenalty = 0
+    for (let i = 0; i < groupUncovered; i++) {
+      if (rng() < 0.20) groupPenalty += Math.abs(group.incomePerPerson)
+    }
+
+    return {
+      ...group,
+      income: normalizeAmount(group.income + groupBonus - groupPenalty),
+      _bureaucratBonus: normalizeAmount(groupBonus),
+      _bureaucratPenalty: normalizeAmount(groupPenalty),
+    }
+  })
+
+  return {
+    entries: [...bureaucratGroups, ...adjustedNonBureaucrats],
+    bureaucratStats: { bureaucratCount, totalNonBureaucratPop, bureaucratCapacity, coveredCount, isFull },
+  }
+}
+
 export async function distributeManufactureIncome(cycleId, startedAt, finishedAt, islandId, populationItems, {
   collection: collectionFn = collection,
   doc: docFn = doc,
@@ -101,6 +145,7 @@ export async function distributeManufactureIncome(cycleId, startedAt, finishedAt
   runTransaction: runTransactionFn = runTransaction,
   serverTimestamp: serverTimestampFn = serverTimestamp,
   db: firestoreDb = db,
+  rng = Math.random,
 } = {}) {
   const islandSnap = await getDocFn(docFn(firestoreDb, 'islands', islandId || DEFAULT_ISLAND_ID))
   if (!islandSnap.exists()) return
@@ -108,7 +153,7 @@ export async function distributeManufactureIncome(cycleId, startedAt, finishedAt
   const manufactureIds = Array.isArray(islandSnap.data()?.manufactures) ? islandSnap.data().manufactures : []
   const loadDeps = { collection: collectionFn, getDocs: getDocsFn, query: queryFn, where: whereFn, documentId: documentIdFn, db: firestoreDb }
   const entries = (await loadManufacturesByIds(manufactureIds, loadDeps)).filter((item) => item.income !== 0)
-  const populationEntries = (populationItems || [])
+  const rawPopulationEntries = (populationItems || [])
     .map((group) => {
       const count = Number(group.count ?? 0)
       const incomePerPerson = normalizeAmount(group.incomePerPerson ?? group.income ?? group.incomePer ?? 0)
@@ -119,10 +164,13 @@ export async function distributeManufactureIncome(cycleId, startedAt, finishedAt
         income: normalizeAmount(incomePerPerson * count),
         incomePerPerson,
         count,
+        faction: group.faction || null,
         type: 'population',
       }
     })
     .filter((item) => item.income !== 0)
+
+  const { entries: populationEntries } = applyBureaucratEffects(rawPopulationEntries, rng)
 
   const combinedEntries = [...entries.map((item) => ({ ...item, type: 'manufacture' })), ...populationEntries]
   if (!combinedEntries.length) return
@@ -174,6 +222,8 @@ export async function distributeManufactureIncome(cycleId, startedAt, finishedAt
         ? [`${label} населення групи "${item.name}"`, `(${item.count} осіб × ${formatAmount(item.incomePerPerson)} 🪙)`]
         : [`${label} мануфактури "${item.name || 'Без назви'}"`]
       if (item.type === 'manufacture' && item.description) commentParts.push(item.description)
+      if (item._bureaucratBonus > 0) commentParts.push(`+${formatAmount(item._bureaucratBonus)} 🪙 бонус бюрократів`)
+      if (item._bureaucratPenalty > 0) commentParts.push(`-${formatAmount(item._bureaucratPenalty)} 🪙 несплачено (без нагляду)`)
       commentParts.push(`за цикл ${cycleLabel}.`)
 
       transaction.set(docFn(txCol), {

--- a/src/store/populationStore.js
+++ b/src/store/populationStore.js
@@ -119,6 +119,23 @@ export const usePopulationStore = defineStore('population', () => {
         })
     })
 
+    const bureaucratStats = computed(() => {
+        const bureaucrats = state.items.filter((g) => g.faction === 'bureaucrats')
+        const nonBureaucrats = state.items.filter((g) => g.faction !== 'bureaucrats')
+        const bureaucratCount = bureaucrats.reduce((s, g) => s + (g.count || 0), 0)
+        const totalNonBureaucratPop = nonBureaucrats.reduce((s, g) => s + (g.count || 0), 0)
+        const bureaucratCapacity = bureaucratCount * 100
+        const coveredCount = Math.min(bureaucratCapacity, totalNonBureaucratPop)
+        const isFull = totalNonBureaucratPop > 0 && coveredCount >= totalNonBureaucratPop
+        const coveragePercent = totalNonBureaucratPop > 0
+            ? normalizeAmount((coveredCount / totalNonBureaucratPop) * 100)
+            : 0
+        const maintenanceCost = normalizeAmount(
+            bureaucrats.reduce((s, g) => s + (groupIncomePerPerson(g)) * (g.count || 0), 0)
+        )
+        return { bureaucratCount, totalNonBureaucratPop, bureaucratCapacity, coveredCount, isFull, coveragePercent, maintenanceCost }
+    })
+
     return {
         ...toRefs(state),
         startListening,
@@ -127,6 +144,7 @@ export const usePopulationStore = defineStore('population', () => {
         totalCountFromGroups,
         populationIncomeTotal,
         groupsAugmented,
+        bureaucratStats,
         setGroupCount,
     }
 })

--- a/src/types/firestore.js
+++ b/src/types/firestore.js
@@ -39,6 +39,8 @@
  * @property {number} count
  * @property {number} incomePerPerson
  * @property {string} description
+ * @property {string} [imageUrl] - Optional card background image URL.
+ * @property {string} [faction] - Optional faction identifier ('archmasters', 'bureaucrats', etc.).
  */
 
 // ─── INTEREST GROUPS ─────────────────────────────────────────────────────────

--- a/src/views/PopulationPage.vue
+++ b/src/views/PopulationPage.vue
@@ -24,7 +24,7 @@
           >
             <div
               class="pop-card"
-              :class="{ 'pop-card-admin': isAdmin }"
+              :class="{ 'pop-card-admin': isAdmin, 'pop-card-bureaucrat': g.isBureaucrat }"
               @click="openEditor(g)"
             >
               <!-- Background image -->
@@ -39,7 +39,17 @@
               <div class="pop-card-stats">
                 <div class="pop-stat-percent wi-number">{{ g.percentRounded }}%</div>
                 <div class="pop-stat-count">{{ g.count }} осіб</div>
-                <div class="pop-stat-income">
+                <template v-if="g.isBureaucrat">
+                  <div class="pop-stat-income">
+                    <v-icon size="12" class="mr-1">mdi-badge-account</v-icon>
+                    {{ formatAmount(g.incomePerPerson) }} 🪙 / особа
+                  </div>
+                  <div class="pop-stat-income">
+                    <v-icon size="12" class="mr-1">mdi-shield-check</v-icon>
+                    Нагляд: {{ g.count * 100 }} осіб
+                  </div>
+                </template>
+                <div v-else class="pop-stat-income">
                   <v-icon size="12" class="mr-1">mdi-gold</v-icon>
                   {{ formatAmount(g.incomePerPerson) }} / особа
                 </div>
@@ -71,6 +81,21 @@
             <span class="pop-total-item">
               <v-icon size="13" class="mr-1">mdi-gold</v-icon>
               Дохід: <strong>{{ formatAmount(populationIncomeTotal) }}</strong> зм
+            </span>
+          </div>
+          <div v-if="bureaucratStats.bureaucratCount > 0" class="pop-bureaucrat-stats">
+            <span class="pop-total-item">
+              <v-icon size="13" class="mr-1">mdi-badge-account</v-icon>
+              Бюрократи: <strong>{{ bureaucratStats.bureaucratCount }}</strong> осіб
+            </span>
+            <span class="pop-total-item">
+              <v-icon size="13" class="mr-1">mdi-shield-check</v-icon>
+              Охоплення: <strong>{{ bureaucratStats.coveragePercent }}%</strong>
+              <span v-if="bureaucratStats.isFull" class="pop-bureaucrat-full wi-success-text">&nbsp;✓ повне</span>
+            </span>
+            <span class="pop-total-item">
+              <v-icon size="13" class="mr-1">mdi-gold</v-icon>
+              Утримання: <strong>{{ formatAmount(bureaucratStats.maintenanceCost) }} зм</strong>
             </span>
           </div>
           <div class="pop-chart-canvas">
@@ -184,10 +209,13 @@ const isAdmin = computed(() => userStore?.isAdmin ?? false)
 /* Pirate palette — matches the design system */
 const PALETTE = ['#c8962a', '#7b4f2e', '#3a6080', '#5a8a3c', '#8b6914', '#4a7a6a', '#7a3a3a', '#5a6a3a']
 
+const bureaucratStats = computed(() => store.bureaucratStats)
+
 const viewRows = computed(() => {
   return store.groupsAugmented.map((g, i) => ({
     ...g,
     color: PALETTE[i % PALETTE.length],
+    isBureaucrat: g.faction === 'bureaucrats',
   }))
 })
 
@@ -648,5 +676,30 @@ async function saveGroup() {
 
 .save-btn :deep(.v-btn__overlay) {
   opacity: 0 !important;
+}
+
+/* ── Bureaucrat card ────────────────────────────────────────── */
+.pop-card-bureaucrat {
+  border-color: var(--wi-sea) !important;
+}
+
+.pop-card-bureaucrat:hover {
+  border-color: rgba(58, 96, 128, 0.8) !important;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.6) !important;
+}
+
+/* ── Bureaucrat stats panel ─────────────────────────────────── */
+.pop-bureaucrat-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 16px;
+  border-top: 1px solid rgba(90, 62, 32, 0.3);
+  border-bottom: 1px solid rgba(90, 62, 32, 0.3);
+}
+
+.pop-bureaucrat-full {
+  color: var(--wi-success);
+  font-size: 0.78rem;
 }
 </style>

--- a/tests/services/cycleService.test.js
+++ b/tests/services/cycleService.test.js
@@ -132,6 +132,140 @@ test('distributeManufactureIncome does nothing when island doc is missing', asyn
   assert.equal(mock.get('treasury/meta').balance, 100);
 });
 
+// ─── distributeManufactureIncome — bureaucrat effects ────────────────────────
+
+test('distributeManufactureIncome — no bureaucrats: income unchanged (regression)', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock',
+    [{ id: 'p1', name: 'Merchants', count: 100, incomePerPerson: 5, description: '' }],
+    { ...mock.firebase, db: mock.db, rng: () => 0 },
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 500);
+  const txs = Object.values(mock.list('treasury-transactions'));
+  assert.equal(txs.length, 1);
+  assert.ok(!txs[0].comment.includes('бюрократ'), 'comment should not mention bureaucrats');
+});
+
+test('distributeManufactureIncome — full coverage: bonus income applied', async () => {
+  // 1 bureaucrat covers 100 people; rng always 0.10 < 0.20 → every covered person pays bonus
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  // bonus per person = max(5 * 0.20, 0.01) = 1.00; 100 people all trigger → +100
+  // civilian income: 100 * 5 + 100 = 600
+  // bureaucrat cost: 1 * (-1) = -1
+  // net: 599
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock',
+    [
+      { id: 'b1', name: 'Бюрократи', count: 1, incomePerPerson: -1, faction: 'bureaucrats', description: '' },
+      { id: 'p1', name: 'Merchants', count: 100, incomePerPerson: 5, description: '' },
+    ],
+    { ...mock.firebase, db: mock.db, rng: () => 0.10 },
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 599);
+  const txs = Object.values(mock.list('treasury-transactions'));
+  const civilianTx = txs.find((t) => t.comment.includes('Merchants'));
+  assert.ok(civilianTx, 'civilian transaction should exist');
+  assert.ok(civilianTx.comment.includes('бонус бюрократів'), 'comment should mention bureaucrat bonus');
+});
+
+test('distributeManufactureIncome — partial coverage: uncovered persons skip payment', async () => {
+  // 1 bureaucrat (capacity=100), civilians=200 → covered=100, uncovered=100, isFull=false
+  // rng always 0.10 < 0.20 → every uncovered person skips
+  // civilian income: 200 * 3 - 100 * 3 = 300
+  // bureaucrat cost: -1
+  // net: 299
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock',
+    [
+      { id: 'b1', name: 'Бюрократи', count: 1, incomePerPerson: -1, faction: 'bureaucrats', description: '' },
+      { id: 'p1', name: 'Farmers', count: 200, incomePerPerson: 3, description: '' },
+    ],
+    { ...mock.firebase, db: mock.db, rng: () => 0.10 },
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 299);
+  const txs = Object.values(mock.list('treasury-transactions'));
+  const civilianTx = txs.find((t) => t.comment.includes('Farmers'));
+  assert.ok(civilianTx.comment.includes('несплачено (без нагляду)'), 'comment should mention penalty');
+  assert.ok(!civilianTx.comment.includes('бонус бюрократів'), 'no bonus when not full coverage');
+});
+
+test('distributeManufactureIncome — bureaucrat group produces withdraw transaction', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 100 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock',
+    [{ id: 'b1', name: 'Бюрократи', count: 3, incomePerPerson: -1, faction: 'bureaucrats', description: '' }],
+    { ...mock.firebase, db: mock.db, rng: () => 0 },
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 97);
+  const txs = Object.values(mock.list('treasury-transactions'));
+  assert.equal(txs.length, 1);
+  assert.equal(txs[0].type, 'withdraw');
+  assert.equal(txs[0].amount, -3);
+});
+
+test('distributeManufactureIncome — zero bureaucrat count: no effect on civilians', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 0 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock',
+    [
+      { id: 'b1', name: 'Бюрократи', count: 0, incomePerPerson: -1, faction: 'bureaucrats', description: '' },
+      { id: 'p1', name: 'Traders', count: 50, incomePerPerson: 4, description: '' },
+    ],
+    { ...mock.firebase, db: mock.db, rng: () => 0.10 },
+  );
+
+  // Bureaucrat group has income 0 so filtered out; only civilian income = 200
+  assert.equal(mock.get('treasury/meta').balance, 200);
+  const txs = Object.values(mock.list('treasury-transactions'));
+  const civilianTx = txs.find((t) => t.comment.includes('Traders'));
+  assert.ok(civilianTx, 'civilian tx exists');
+  assert.ok(!civilianTx.comment.includes('бюрократ'), 'no bureaucrat mention when count=0');
+});
+
+test('distributeManufactureIncome — only bureaucrats, no civilians: single withdraw tx', async () => {
+  const mock = createMockFirestore({
+    'islands/island_rock': { manufactures: [] },
+    'treasury/meta': { balance: 50 },
+  });
+
+  await distributeManufactureIncome(
+    'cycle-1', '1 Hammer 1490', null, 'island_rock',
+    [{ id: 'b1', name: 'Бюрократи', count: 10, incomePerPerson: -1, faction: 'bureaucrats', description: '' }],
+    { ...mock.firebase, db: mock.db, rng: () => 0.10 },
+  );
+
+  assert.equal(mock.get('treasury/meta').balance, 40);
+  const txs = Object.values(mock.list('treasury-transactions'));
+  assert.equal(txs.length, 1);
+  assert.equal(txs[0].type, 'withdraw');
+});
+
 // ─── distributeBuildingFaithIncome ───────────────────────────────────────────
 
 test('distributeBuildingFaithIncome distributes faith to eligible clergy', async () => {


### PR DESCRIPTION
## Summary

- **New faction: Бюрократи** — population group with `faction: 'bureaucrats'` and `incomePerPerson: -1` (maintenance cost flows through the existing negative-income path)
- **Cycle mechanics:** 1 bureaucrat covers 100 people. When coverage is 100%, each covered person has a 20% chance to pay a bonus tax (+20% of their income, minimum 0.01). People *not* covered always have a 20% chance to skip payment entirely. Logic lives in the new `applyBureaucratEffects()` pure helper in `cycleService.js`.
- **Schema catch-up:** `PopulationDoc` in `firestore.js` now documents the `imageUrl` and `faction` fields that were already in use (Archmasters) but missing from the typedef.
- **Store:** `bureaucratStats` computed in `populationStore` exposes coverage %, `isFull`, and `maintenanceCost` for the UI.
- **UI:** Bureaucrat cards on the Population page show a sea-blue border, coverage capacity ("Нагляд: N осіб"), and maintenance cost. The chart panel shows a coverage block with a "✓ повне" badge when fully covered.
- **Tests:** 6 new unit tests cover the bonus path, penalty path, withdraw tx format, zero-count, and civilians-only edge cases. All 22 tests pass.

## Test plan

- [ ] `node --test tests/services/cycleService.test.js` — all 22 tests green
- [ ] Open Population page — bureaucrat card has sea-blue border, shows coverage capacity and maintenance cost
- [ ] Chart panel shows bureaucrat coverage block when `bureaucratCount > 0`
- [ ] Add a `population` Firestore doc with `faction: 'bureaucrats'`, `incomePerPerson: -1`, `count: 5`; trigger a cycle rollover; verify `treasury-transactions` contains a `-5` withdraw for bureaucrats, and civilian transactions have bonus/penalty comment annotations

🤖 Generated with [Claude Code](https://claude.ai/claude-code)