### PR TITLE
fix: treasury pagination always showing 'all records loaded'

### DIFF
--- a/src/components/TreasuryTransactions.vue
+++ b/src/components/TreasuryTransactions.vue
@@ -70,7 +70,7 @@ import { formatAmount } from "@/utils/formatters"
 const treasury = useTreasuryStore()
 const tx = computed(() => treasury.tx)
 const loading = computed(() => treasury.loading)
-const hasMore = computed(() => !!treasury._lastDoc)
+const hasMore = computed(() => treasury.hasMore)
 
 function formatDate(v) {
   if (!v) return "—"

--- a/src/store/treasuryStore.js
+++ b/src/store/treasuryStore.js
@@ -51,6 +51,7 @@ export const useTreasuryStore = defineStore('treasury', () => {
   const tx = ref([])
   const loading = ref(false)
   const error = ref(null)
+  const hasMore = ref(false)
   const _pageSize = 20
   let _lastDoc = null
   let _unsubMeta = null
@@ -91,6 +92,7 @@ export const useTreasuryStore = defineStore('treasury', () => {
       const snap = await getDocs(q)
       tx.value = snap.docs.map((d) => ({ id: d.id, ...d.data() }))
       _lastDoc = snap.docs[snap.docs.length - 1] || null
+      hasMore.value = snap.docs.length === _pageSize
     } catch (e) {
       error.value = e?.message || String(e)
     } finally {
@@ -113,6 +115,7 @@ export const useTreasuryStore = defineStore('treasury', () => {
       const snap = await getDocs(q)
       tx.value.push(...snap.docs.map((d) => ({ id: d.id, ...d.data() })))
       _lastDoc = snap.docs[snap.docs.length - 1] || null
+      hasMore.value = snap.docs.length === _pageSize
     } catch (e) {
       error.value = e?.message || String(e)
     } finally {
@@ -140,6 +143,7 @@ export const useTreasuryStore = defineStore('treasury', () => {
     tx,
     loading,
     error,
+    hasMore,
     subscribeBalance,
     unsubscribeBalance,
     loadFirstPage,


### PR DESCRIPTION
## What changed

- `src/store/treasuryStore.js` — added a reactive `hasMore` ref, set it to `snap.docs.length === _pageSize` after both `loadFirstPage` and `loadNextPage`, and exported it from the store
- `src/components/TreasuryTransactions.vue` — replaced `!!treasury._lastDoc` with `treasury.hasMore`

## Why

`_lastDoc` in the store was a plain `let` variable (non-reactive) and was never included in the store's `return`. As a result `treasury._lastDoc` in the component was always `undefined`, `hasMore` was always `false`, and the footer permanently showed "Всі записи завантажено" with the button disabled — regardless of how many records existed in Firestore.

## Reviewer notes

The `hasMore` heuristic (`snap.docs.length === _pageSize`) matches the existing cursor logic: a full page means there may be more; a short page means we've reached the end. Edge case: if the total number of records is an exact multiple of `_pageSize`, one extra empty fetch will occur before `hasMore` flips to `false` — this is the standard Firestore pagination trade-off and consistent with how `_lastDoc` was previously used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)