### PR TITLE
fix: Deva faith overflow burn, Park building population growth, cycle days input

### DIFF
--- a/src/services/cycleService.js
+++ b/src/services/cycleService.js
@@ -316,6 +316,46 @@ export async function distributeBuildingFaithIncome(cycleId, {
   }
 }
 
+export async function applyParkBuildingGrowth(islandId, {
+  collection: collectionFn = collection,
+  doc: docFn = doc,
+  getDoc: getDocFn = getDoc,
+  getDocs: getDocsFn = getDocs,
+  updateDoc: updateDocFn = updateDoc,
+  db: firestoreDb = db,
+} = {}) {
+  const buildingsSnap = await getDocsFn(collectionFn(firestoreDb, 'buildings'))
+  const parkBuildings = buildingsSnap.docs
+    .map((d) => ({ id: d.id, ref: d.ref, ...d.data() }))
+    .filter((b) => b.growthPerCycle && Number(b.currentLvl) > 0)
+
+  if (!parkBuildings.length) return
+
+  for (const building of parkBuildings) {
+    const lvl = Number(building.currentLvl)
+    const growth = Number(building.growthPerCycle?.[lvl] ?? 0)
+    if (!growth) continue
+
+    const peasantsRef = docFn(firestoreDb, 'population', 'peasants')
+    const peasantsSnap = await getDocFn(peasantsRef)
+    if (peasantsSnap.exists()) {
+      await updateDocFn(peasantsRef, { count: Number(peasantsSnap.data().count ?? 0) + growth })
+    }
+
+    const islandRef = docFn(firestoreDb, 'islands', islandId || DEFAULT_ISLAND_ID)
+    const islandSnap = await getDocFn(islandRef)
+    if (islandSnap.exists()) {
+      await updateDocFn(islandRef, { population: Number(islandSnap.data().population ?? 0) + growth })
+    }
+
+    const unknownReligionRef = docFn(firestoreDb, 'religions', 'Unknown')
+    const unknownReligionSnap = await getDocFn(unknownReligionRef)
+    if (unknownReligionSnap.exists()) {
+      await updateDocFn(unknownReligionRef, { followers: Number(unknownReligionSnap.data().followers ?? 0) + growth })
+    }
+  }
+}
+
 export async function createNewCycleWithEffects({
   startedDate,
   notes = '',
@@ -374,6 +414,7 @@ export async function createNewCycleWithEffects({
     convertedFollowers: 0,
     result: 0,
   })
+  await applyParkBuildingGrowth(islandId, sharedDeps)
   await distributeBuildingFaithIncome(cycleDoc.id, sharedDeps)
   await distributeManufactureIncome(cycleDoc.id, startedAt, null, islandId, populationItems, sharedDeps)
   await settlePreviousSpellRequestsFn()

--- a/src/types/firestore.js
+++ b/src/types/firestore.js
@@ -27,6 +27,8 @@
  * @property {string} id
  * @property {string} name
  * @property {number} cost
+ * @property {Record<number, number>} [growthPerCycle] - Optional map of level → population growth per cycle (e.g. Park building). Keys are level numbers (1–3).
+ * @property {number} [currentLvl] - Current building level (0 = not built). Used together with growthPerCycle.
  */
 
 // ─── POPULATION ──────────────────────────────────────────────────────────────

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -15,12 +15,21 @@
           placeholder="Оберіть дату початку"
         />
         <v-text-field
+          v-model.number="cycleDaysInput"
+          label="Або вкажіть кількість днів циклу"
+          type="number"
+          min="1"
+          density="comfortable"
+          hide-details="auto"
+          class="my-3"
+        />
+        <v-text-field
           :model-value="cycleDurationLabel"
           label="Тривалість попереднього циклу"
           density="comfortable"
           hide-details="auto"
           readonly
-          class="my-3"
+          class="mb-3"
         />
         <v-textarea
           v-model="cycleForm.notes"
@@ -402,7 +411,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch, nextTick } from 'vue';
 import {
   addDoc,
   collection,
@@ -445,6 +454,38 @@ const cycleForm = reactive({
   startedDate: null,
   notes: '',
 });
+const cycleDaysInput = ref(null);
+let _daysUpdatingDate = false;
+let _dateUpdatingDays = false;
+
+watch(cycleDaysInput, (days) => {
+  if (_dateUpdatingDays) return
+  const n = Number(days)
+  if (!n || n < 1) return
+  const previousStart = parseFaerunDate(latestCycle.value?.startedAt)
+  if (!previousStart) return
+  _daysUpdatingDate = true
+  const totalDays = previousStart.month * 30 + (previousStart.day - 1) + (n - 1)
+  cycleForm.startedDate = {
+    day: (totalDays % 30) + 1,
+    month: Math.floor(totalDays / 30) % 12,
+    year: previousStart.year + Math.floor(totalDays / 360),
+  }
+  nextTick(() => { _daysUpdatingDate = false })
+})
+
+watch(() => cycleForm.startedDate, (date) => {
+  if (_daysUpdatingDate) return
+  const start = normalizeFaerunDate(date)
+  const previousStart = parseFaerunDate(latestCycle.value?.startedAt)
+  if (!start || !previousStart) return
+  const diff = diffInDays(previousStart, start)
+  if (diff !== null && diff > 0) {
+    _dateUpdatingDays = true
+    cycleDaysInput.value = diff
+    nextTick(() => { _dateUpdatingDays = false })
+  }
+})
 
 const heroes = ref([]);
 const religions = ref([]);
@@ -706,6 +747,7 @@ async function createCycle() {
     cycleForm.notes = '';
     await loadLatestCycle();
     cycleForm.startedDate = suggestNextCycleDate();
+    cycleDaysInput.value = null;
   } catch (error) {
     console.error('[admin] Failed to create cycle', error);
     cycleError.value = 'Не вдалося створити новий цикл.';

--- a/src/views/ReligionPage.vue
+++ b/src/views/ReligionPage.vue
@@ -2042,7 +2042,7 @@ async function applyCelestialTransfer() {
         selectedCelestialBonus: celestialTransferForm.selectedBonus || '',
       })
       transaction.update(devaRef, {
-        devaFaith: Number(d.devaFaith ?? 0) + total,
+        devaFaith: Math.min(100, Number(d.devaFaith ?? 0) + total),
       })
     })
   } catch (e) {


### PR DESCRIPTION
## Summary

- **Deva overflow burn**: `applyCelestialTransfer` now caps `devaFaith` at 100 — transferred faith is still fully recorded on the clergy's `celestialTransferred`, but any amount exceeding the max burns instead of pushing the gauge past 125/100.
- **Park building population growth**: Added `applyParkBuildingGrowth()` which runs on every new cycle. It reads all buildings with `growthPerCycle` + `currentLvl > 0`, then increments `population/peasants` count, the island's `population` field, and `religions/Unknown` followers by the appropriate level's growth value.
- **Cycle days input**: Admin cycle form now has a "кількість днів циклу" number field that two-way syncs with the date picker — entering a day count updates the date and picking a date updates the days count.

## Notes for reviewer

- Park growth looks up `population/peasants` and `religions/Unknown` by document ID directly.
- The days ↔ date sync uses two watches with a flag to prevent circular updates; the days value corresponds 1:1 with what `diffInDays` returns (inclusive count).
- `src/types/firestore.js` updated with `growthPerCycle` and `currentLvl` fields on `BuildingDoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)