### PR TITLE
feat: split ManufacturesPage into Manufactures and Auto-income tabs

### DIFF
--- a/src/types/firestore.js
+++ b/src/types/firestore.js
@@ -252,6 +252,7 @@
  * @property {string} description
  * @property {number} income
  * @property {string} incomeDestination - 'treasury' or 'guild:{guildId}'
+ * @property {'manufacture'|'auto'} [type] - 'manufacture' (default) or 'auto' (auto income/expense)
  */
 
 // ─── HEROES & CRAFTING ───────────────────────────────────────────────────────

--- a/src/views/ManufacturesPage.md
+++ b/src/views/ManufacturesPage.md
@@ -3,25 +3,32 @@
 Route: `/islands/:islandId/manufactures` (child of IslandsPage).
 
 ## Purpose
-Lists manufactures linked to the island. Admins can add new ones or edit existing ones via a dialog.
+Lists manufactures and auto-income/expense entries linked to the island, split across two tabs.
+
+## Tabs
+- **Мануфактури** — items with `type === 'manufacture'` or no `type` field (backward compat). Physical production facilities like Ферма Берика, Жир та Олія Моніки.
+- **Авто-доходи** — items with `type === 'auto'`. Automatic periodic income or expense entries not tied to a physical manufacture.
 
 ## Data loading
 Manufactures are stored as an array of IDs in `island.manufactures`. The page loads them directly from Firestore `manufactures` collection (chunked in batches of 10). Results are sorted to preserve the original order from the island document. No Pinia store — direct Firestore access.
 
+## Item type
+Each document has a `type` field: `'manufacture'` (default) or `'auto'`. Legacy documents without a `type` are treated as `'manufacture'`. The dialog exposes a type selector so admins can reassign items between tabs.
+
 ## Income destination
-Each manufacture has `incomeDestination`:
+Each item has `incomeDestination`:
 - `'treasury'` — income goes to island treasury
 - `'guild:{guildId}'` — income goes to a specific guild
 
 Display label resolved from `guildStore.guilds`. Icon: `mdi-anchor` for treasury, `mdi-sword-cross` for guild.
 
 ## Add/Edit dialog (admin only)
-Single dialog handles both modes (`dialogMode: 'add' | 'edit'`).
+Single dialog handles both modes (`dialogMode: 'add' | 'edit'`). When adding, `type` defaults to the currently active tab.
 
 **Add**: creates a new document in `manufactures` collection, then `arrayUnion`s its ID into `island.manufactures`.  
 **Edit**: updates the existing document in place; updates local `manufactures.value` array optimistically.
 
-Form fields: name (required), description, income (decimal, step 0.01), incomeDestination (select).
+Form fields: name (required), description, income (decimal, step 0.01), incomeDestination (select), type (select).
 
 ## Stores
 - `useIslandStore` — `data.manufactures`, `data.id`

--- a/src/views/ManufacturesPage.vue
+++ b/src/views/ManufacturesPage.vue
@@ -1,11 +1,23 @@
 <template>
   <div class="manufactures-page">
 
+    <!-- Tabs -->
+    <v-tabs v-model="activeTab" align-tabs="start" class="mfg-tabs mb-4">
+      <v-tab value="manufactures">
+        <v-icon start>mdi-factory</v-icon>
+        Мануфактури
+      </v-tab>
+      <v-tab value="auto">
+        <v-icon start>mdi-autorenew</v-icon>
+        Авто-доходи
+      </v-tab>
+    </v-tabs>
+
     <!-- Header row -->
     <div class="mfg-header">
       <div class="mfg-title">
-        <v-icon class="mr-2" size="20">mdi-factory</v-icon>
-        Мануфактури острова
+        <v-icon class="mr-2" size="20">{{ activeTab === 'manufactures' ? 'mdi-factory' : 'mdi-autorenew' }}</v-icon>
+        {{ activeTab === 'manufactures' ? 'Мануфактури острова' : 'Авто-доходи та витрати' }}
       </div>
       <v-btn v-if="isAdmin" class="add-btn" prepend-icon="mdi-plus" @click="openAddDialog">
         Додати
@@ -21,15 +33,15 @@
       <v-icon class="mr-2" size="16">mdi-skull-crossbones</v-icon>
       {{ error }}
     </div>
-    <div v-else-if="!manufactures.length" class="mfg-state">
+    <div v-else-if="!visibleItems.length" class="mfg-state">
       <v-icon class="mr-2" size="16">mdi-anchor</v-icon>
-      Наразі на острові немає мануфактур.
+      {{ activeTab === 'manufactures' ? 'Наразі на острові немає мануфактур.' : 'Наразі немає авто-доходів чи витрат.' }}
     </div>
 
     <!-- Cards grid -->
     <v-row v-else class="mfg-grid">
       <v-col
-        v-for="(item, index) in manufactures"
+        v-for="(item, index) in visibleItems"
         :key="item.key"
         cols="12"
         md="6"
@@ -77,8 +89,8 @@
     <v-dialog v-model="dialogOpen" max-width="520" :fullscreen="$vuetify.display.smAndDown" scrollable>
       <v-card class="mfg-dialog">
         <div class="mfg-dialog-header">
-          <v-icon class="mr-2">mdi-factory</v-icon>
-          {{ dialogMode === 'add' ? 'Нова мануфактура' : 'Редагувати мануфактуру' }}
+          <v-icon class="mr-2">{{ dialogMode === 'add' ? (activeTab === 'manufactures' ? 'mdi-factory' : 'mdi-autorenew') : 'mdi-feather' }}</v-icon>
+          {{ dialogMode === 'add' ? (activeTab === 'manufactures' ? 'Нова мануфактура' : 'Новий авто-дохід') : 'Редагувати запис' }}
         </div>
         <v-card-text class="mfg-dialog-body">
           <v-text-field
@@ -120,6 +132,17 @@
             variant="outlined"
             density="compact"
             hide-details="auto"
+            class="mb-3"
+          />
+          <v-select
+            v-model="form.type"
+            :items="typeOptions"
+            item-title="title"
+            item-value="value"
+            label="Тип запису"
+            variant="outlined"
+            density="compact"
+            hide-details="auto"
           />
           <div v-if="formError" class="mfg-dialog-error">
             <v-icon size="14" class="mr-1">mdi-skull-crossbones</v-icon>{{ formError }}
@@ -155,6 +178,7 @@ const userStore = useUserStore()
 const guildStore = useGuildStore()
 const isAdmin = computed(() => !!userStore.isAdmin)
 
+const activeTab = ref('manufactures')
 const manufactures = ref([])
 const loading = ref(false)
 const error = ref('')
@@ -162,7 +186,20 @@ const dialogOpen = ref(false)
 const dialogMode = ref('add')
 const saving = ref(false)
 const formError = ref('')
-const form = ref({ id: null, name: '', description: '', income: 0, incomeDestination: 'treasury' })
+const form = ref({ id: null, name: '', description: '', income: 0, incomeDestination: 'treasury', type: 'manufacture' })
+
+const visibleItems = computed(() =>
+  manufactures.value.filter(item =>
+    activeTab.value === 'manufactures'
+      ? (item.type === 'manufacture' || !item.type)
+      : item.type === 'auto'
+  )
+)
+
+const typeOptions = [
+  { title: 'Мануфактура', value: 'manufacture' },
+  { title: 'Авто-дохід / витрата', value: 'auto' },
+]
 
 const incomeDestinationOptions = computed(() => ([
   { title: 'Скарбниця острова', value: 'treasury' },
@@ -196,6 +233,7 @@ async function loadManufactures(ids) {
           description: data.description || '',
           income: normalizeAmount(data.income || 0),
           incomeDestination: normalizeIncomeDestination(data.incomeDestination),
+          type: data.type === 'auto' ? 'auto' : 'manufacture',
         })
       })
     }
@@ -213,7 +251,7 @@ async function loadManufactures(ids) {
 
 function openAddDialog() {
   dialogMode.value = 'add'
-  form.value = { id: null, name: '', description: '', income: 0, incomeDestination: 'treasury' }
+  form.value = { id: null, name: '', description: '', income: 0, incomeDestination: 'treasury', type: activeTab.value === 'auto' ? 'auto' : 'manufacture' }
   formError.value = ''
   dialogOpen.value = true
 }
@@ -226,6 +264,7 @@ function openEditDialog(item) {
     description: item.description || '',
     income: item.income || 0,
     incomeDestination: normalizeIncomeDestination(item.incomeDestination),
+    type: item.type === 'auto' ? 'auto' : 'manufacture',
   }
   formError.value = ''
   dialogOpen.value = true
@@ -238,7 +277,8 @@ async function saveManufacture() {
   saving.value = true
   try {
     const incomeDestination = normalizeIncomeDestination(form.value.incomeDestination)
-    const payload = { name, description: form.value.description?.trim() || '', income: normalizeAmount(form.value.income || 0), incomeDestination }
+    const type = form.value.type === 'auto' ? 'auto' : 'manufacture'
+    const payload = { name, description: form.value.description?.trim() || '', income: normalizeAmount(form.value.income || 0), incomeDestination, type }
     if (dialogMode.value === 'add') {
       if (!island.value?.id) throw new Error('Острів не вибрано.')
       const docRef = await addDoc(collection(db, 'manufactures'), payload)
@@ -291,11 +331,34 @@ watch(() => island.value?.manufactures, (ids) => { loadManufactures(ids) }, { de
   padding-bottom: 16px;
 }
 
+.mfg-tabs {
+  border-bottom: 1px solid var(--wi-border);
+  margin-bottom: 0 !important;
+}
+
+.mfg-tabs :deep(.v-tab) {
+  font-family: var(--wi-font-heading) !important;
+  letter-spacing: 0.06em !important;
+  font-size: 0.82rem !important;
+  color: var(--wi-text-muted) !important;
+  text-transform: uppercase !important;
+  min-width: 120px !important;
+}
+
+.mfg-tabs :deep(.v-tab--selected) {
+  color: var(--wi-gold) !important;
+}
+
+.mfg-tabs :deep(.v-tabs-slider) {
+  background-color: var(--wi-gold) !important;
+}
+
 .mfg-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 20px;
+  margin-top: 16px;
 }
 
 .mfg-title {


### PR DESCRIPTION
## Summary
- Adds two tabs to ManufacturesPage: **Мануфактури** and **Авто-доходи**
- Introduces a `type` field (`'manufacture'` | `'auto'`) on manufacture Firestore documents; existing docs without a type default to the Manufactures tab (backward compat)
- Dialog exposes a "Тип запису" selector; pre-selects the current tab's type when adding
- Gold flow via `cycleService` is unaffected — it assigns its own internal type tag and never reads the Firestore `type` field; all 22 cycle tests pass

## Test plan
- [ ] Open ManufacturesPage — existing items all appear under Мануфактури tab
- [ ] Switch to Авто-доходи tab — shows empty state
- [ ] Edit an auto-income item (e.g. Витрати на школу), change type to "Авто-дохід / витрата", save — item moves to Авто-доходи tab
- [ ] Add a new item from each tab — type pre-selects correctly
- [ ] Run cycle — treasury/guild balances update as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)