### PR TITLE
[codex] Fix buildings map subtitle

### DIFF
--- a/src/views/BuildingsPage.vue
+++ b/src/views/BuildingsPage.vue
@@ -2,7 +2,7 @@
   <v-container class="buildings-page">
     <WiPageHeader
       title="Мапа острова"
-      subtitle="Актуальна інтерактивна мапа з позначками ведеться в LegendKeeper. Дані будівель-постачальників нижче залишаються збереженими в застосунку."
+      subtitle="Актуальна інтерактивна мапа з позначками ведеться в LegendKeeper.
       icon="mdi-map"
     />
 

--- a/src/views/BuildingsPage.vue
+++ b/src/views/BuildingsPage.vue
@@ -2,7 +2,7 @@
   <v-container class="buildings-page">
     <WiPageHeader
       title="Мапа острова"
-      subtitle="Актуальна інтерактивна мапа з позначками ведеться в LegendKeeper.
+      subtitle="Актуальна інтерактивна мапа з позначками ведеться в LegendKeeper."
       icon="mdi-map"
     />
 


### PR DESCRIPTION
## Summary

- Fix the Buildings page header subtitle so the Vue template is valid.
- Keep the copy focused on the LegendKeeper map handoff.

## Validation

- Vite production build passed via bundled Node.

No deploy commands run.